### PR TITLE
Generates list of 'Parameter' instead of 'Output' for remaining_inputs.

### DIFF
--- a/python/openvino_tokenizers/utils.py
+++ b/python/openvino_tokenizers/utils.py
@@ -44,7 +44,8 @@ def connect_models(
             # target.replace_source_output(model1_output)  # TODO: Produces incorrect topology
 
     new_inputs = first.get_parameters()
-    remaining_inputs = [input_ for input_ in second.inputs if input_ not in aligned_second_inputs]
+    aligned_second_input_names = [ second_input.get_any_name() for second_input in aligned_second_inputs ]
+    remaining_inputs = [ param for param in second.get_parameters() if param.get_friendly_name() not in aligned_second_input_names ]
     if keep_second_model_unaligned_inputs:
         new_inputs.extend(remaining_inputs)
     elif remaining_inputs:


### PR DESCRIPTION
The original code generats a list consists of 'Parameter' and 'Output' for remaining_inputs, that causes error on generating a new connected model with Model(outputs, inputs, model_name).

I modified the code to generate a list of 'Parameter'.