### PR TITLE
[WHEEL] Support of OV nightly packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "openvino~=2024.1.0.0"
+    # support of nightly openvino packages with dev suffix
+    "openvino~=2024.1.0.0.dev"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Jira ticket: 136121

According to https://peps.python.org/pep-0440/#compatible-release 
openvino~=2024.1.0.0.dev (analog >= 2024.1.0.0.devN, == 2024.1.0.*) should suite the both cases:
1) ov == 2024.1.0
2) ov == 2024.1.0.devN