### PR TITLE
Fixed compatibility with OpenVINO 2024.0

### DIFF
--- a/src/ov_extension.cpp
+++ b/src/ov_extension.cpp
@@ -10,7 +10,7 @@
 
 #ifdef OpenVINO_Frontend_TensorFlow_FOUND
 #include <openvino/frontend/tensorflow/extension/conversion.hpp>
-#define OPENVINO_TOKENIZERS_TENSORFLOW_CONVERSION_EXTENSIONS                                                                                     \
+#define OPENVINO_TOKENIZERS_TENSORFLOW_CONVERSION_EXTENSIONS_GENERIC                                                                             \
     std::make_shared<ov::frontend::tensorflow::ConversionExtension>("WordpieceTokenizeWithOffsets", translate_wordpiece_tokenize_with_offsets),  \
     std::make_shared<ov::frontend::tensorflow::ConversionExtension>("RegexSplitWithOffsets", translate_regex_split_with_offsets),                \
     std::make_shared<ov::frontend::tensorflow::ConversionExtension>("NormalizeUTF8", translate_normalize_utf8),                                  \
@@ -19,13 +19,19 @@
     std::make_shared<ov::frontend::tensorflow::ConversionExtension>("RaggedTensorToSparse", translate_ragged_tensor_to_sparse),                  \
     std::make_shared<ov::frontend::tensorflow::ConversionExtension>("StringLower", translate_string_lower),                                      \
     std::make_shared<ov::frontend::tensorflow::ConversionExtension>("StaticRegexReplace", translate_static_regex_replace),                       \
-    std::make_shared<ov::frontend::tensorflow::ConversionExtension>("LookupTableFind", translate_lookup_table_find_op),                          \
-    std::make_shared<ov::frontend::tensorflow::ConversionExtension>("LookupTableFindV2", translate_lookup_table_find_op),                        \
     std::make_shared<ov::frontend::tensorflow::ConversionExtension>("StringSplitV2", translate_string_split),                                    \
     std::make_shared<ov::frontend::tensorflow::ConversionExtension>("RaggedTensorToTensor", translate_ragged_tensor_to_tensor),                  \
-    std::make_shared<ov::frontend::tensorflow::ConversionExtension>("Equal", translate_equal)
+    std::make_shared<ov::frontend::tensorflow::ConversionExtension>("Equal", translate_equal),
+#if OPENVINO_VERSION_MAJOR >= 2024 && OPENVINO_VERSION_MINOR >= 1
+#define OPENVINO_TOKENIZERS_TENSORFLOW_CONVERSION_EXTENSIONS_2024_1                                                                              \
+    std::make_shared<ov::frontend::tensorflow::ConversionExtension>("LookupTableFind", translate_lookup_table_find_op),                          \
+    std::make_shared<ov::frontend::tensorflow::ConversionExtension>("LookupTableFindV2", translate_lookup_table_find_op),
 #else
-#define OPENVINO_TOKENIZERS_TENSORFLOW_CONVERSION_EXTENSIONS
+#define OPENVINO_TOKENIZERS_TENSORFLOW_CONVERSION_EXTENSIONS_2024_1
+#endif
+#else
+#define OPENVINO_TOKENIZERS_TENSORFLOW_CONVERSION_EXTENSIONS_GENERIC
+#define OPENVINO_TOKENIZERS_TENSORFLOW_CONVERSION_EXTENSIONS_2024_1
 #endif
 
 // clang-format off
@@ -55,7 +61,8 @@ OPENVINO_CREATE_EXTENSIONS(
             std::make_shared<ov::OpExtension<TemplateExtension::SentencepieceTokenizer>>(),
             std::make_shared<ov::OpExtension<TemplateExtension::SentencepieceDetokenizer>>(),
             std::make_shared<ov::OpExtension<TemplateExtension::SentencepieceStreamDetokenizer>>(),
-            OPENVINO_TOKENIZERS_TENSORFLOW_CONVERSION_EXTENSIONS
+            OPENVINO_TOKENIZERS_TENSORFLOW_CONVERSION_EXTENSIONS_GENERIC
+            OPENVINO_TOKENIZERS_TENSORFLOW_CONVERSION_EXTENSIONS_2024_1
 }));
 //! [ov_extension:entry_point]
 // clang-format on

--- a/src/tensorflow_translators.cpp
+++ b/src/tensorflow_translators.cpp
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "openvino/frontend/tensorflow/hash_table.hpp"
+#include "openvino/core/version.hpp"
+
+#if OPENVINO_VERSION_MAJOR >= 2024 && OPENVINO_VERSION_MINOR >= 1
+#  include "openvino/frontend/tensorflow/hash_table.hpp"
+#endif
 
 #include "openvino/op/util/framework_node.hpp"
 #include "openvino/opsets/opset13.hpp"
@@ -210,6 +214,8 @@ ov::OutputVector translate_string_lower(const ov::frontend::NodeContext& node) {
     return { string_lower_result };
 }
 
+#if OPENVINO_VERSION_MAJOR >= 2024 && OPENVINO_VERSION_MINOR >= 1
+
 OutputVector translate_lookup_table_find_op(const ov::frontend::tensorflow::NodeContext& node) {
     FRONT_END_GENERAL_CHECK(node.get_input_size() == 3, "LookupTableFind or LookupTableFindV2 expects 3 inputs");
     auto table_handle = as_type_ptr<ov::frontend::tensorflow::HashTable>(node.get_input_by_reference(0).get_node_shared_ptr());
@@ -297,6 +303,8 @@ OutputVector translate_lookup_table_find_op(const ov::frontend::tensorflow::Node
 
     return { lookup_values };
 }
+
+#endif
 
 NamedOutputVector translate_string_split(const ov::frontend::NodeContext& node) {
     auto node_name = node.get_name();

--- a/src/tensorflow_translators.hpp
+++ b/src/tensorflow_translators.hpp
@@ -5,9 +5,12 @@
 #pragma once
 
 #include <openvino/frontend/node_context.hpp>
+
 #ifdef OpenVINO_Frontend_TensorFlow_FOUND
-#include <openvino/frontend/tensorflow/node_context.hpp>
+#  include <openvino/frontend/tensorflow/node_context.hpp>
+#  if OPENVINO_VERSION_MAJOR >= 2024 && OPENVINO_VERSION_MINOR >= 1
 ov::OutputVector translate_lookup_table_find_op(const ov::frontend::tensorflow::NodeContext& node);
+#  endif
 ov::frontend::NamedOutputVector translate_string_split(const ov::frontend::NodeContext& node);
 #endif
 


### PR DESCRIPTION
Current version of tokenizers is not compatible with 2024.0 release
Issue is here https://github.com/openvinotoolkit/openvino.genai/actions/runs/8613730528/job/23608791093?pr=315