### PR TITLE
[CI] Temporary removed dependency version of OpenVINO

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 
 dependencies = [
     # support of nightly openvino packages with dev suffix
-    "openvino~=2024.2.0.0.dev"
+    "openvino"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Like https://github.com/openvinotoolkit/openvino_tokenizers/pull/108 
will be reverted when OV CI switched to the new 2024.3 version