### PR TITLE
Switch default skip tokens flag behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ This command is the equivalent of minimal installation. Install tokenizers conve
 ```bash
 pip install transformers[sentencepiece] tiktoken
 ```
-:warning: Latest commit of OpenVINO Tokenizers might rely on features that are not present in the release OpenVINO version. 
-Use [a nightly build](https://docs.openvino.ai/2024/get-started/install-openvino.html?VERSION=NIGHTLY) of OpenVINO or build 
+:warning: Latest commit of OpenVINO Tokenizers might rely on features that are not present in the release OpenVINO version.
+Use [a nightly build](https://docs.openvino.ai/2024/get-started/install-openvino.html?VERSION=NIGHTLY) of OpenVINO or build
 OpenVINO Tokenizers from a release branch if you have issues with the build process.
 
 ### Build and install for development
@@ -214,7 +214,7 @@ hf_model = AutoModelForCausalLM.from_pretrained(model_checkpoint, use_cache=Fals
 
 # convert hf tokenizer
 text_input = ["Quick brown fox jumped "]
-ov_tokenizer, ov_detokenizer = convert_tokenizer(hf_tokenizer, with_detokenizer=True, skip_special_tokens=True)
+ov_tokenizer, ov_detokenizer = convert_tokenizer(hf_tokenizer, with_detokenizer=True)
 compiled_tokenizer = compile_model(ov_tokenizer)
 
 # transform input text into tokens
@@ -251,15 +251,15 @@ compiled_detokenizer = compile_model(ov_detokenizer)
 ov_output = compiled_detokenizer(ov_token_ids)["string_output"]
 hf_output = hf_tokenizer.batch_decode(hf_token_ids, skip_special_tokens=True)
 print(f"OpenVINO output string: `{ov_output}`")
-# OpenVINO output string: `['<s> Quick brown fox was walking through the forest. He was looking for something']`
+# OpenVINO output string: `['Quick brown fox was walking through the forest. He was looking for something']`
 print(f"HuggingFace output string: `{hf_output}`")
 # HuggingFace output string: `['Quick brown fox was walking through the forest. He was looking for something']`
 ```
 
 ### TensorFlow Text Integration
 
-OpenVINO Tokenizers include converters for certain TensorFlow Text operations. 
-Currently, only the MUSE model is supported. 
+OpenVINO Tokenizers include converters for certain TensorFlow Text operations.
+Currently, only the MUSE model is supported.
 Here is an example of model conversion and inference:
 
 ```python

--- a/python/openvino_tokenizers/cli.py
+++ b/python/openvino_tokenizers/cli.py
@@ -58,24 +58,54 @@ def get_parser() -> ArgumentParser:
             "Example: `convert_tokenizer SimianLuo/LCM_Dreamshaper_v7 --subfolder tokenizer`"
         ),
     )
-    parser.add_argument(
+    special_tokens_group = parser.add_mutually_exclusive_group()
+    special_tokens_group.add_argument(
+        "--add-special-tokens",
+        "--add_special_tokens",
+        required=False,
+        action="store_true",
+        help=(
+            "Tokenizer will add special tokens during tokenization, similar to "
+            "huggingface_tokenizer.encode(texts, add_special_tokens=True). Not affects tiktoken-base tokenizers. "
+            "Not compatible with --not-add-special-tokens."
+        ),
+    )
+    special_tokens_group.add_argument(
         "--not-add-special-tokens",
         "--not_add_special_tokens",
         required=False,
         action="store_false",
+        default=False,
         help=(
             "Tokenizer won't add special tokens during tokenization, similar to "
-            "huggingface_tokenizer.encode(texts, add_special_tokens=False). Not affects tiktoken-base tokenizers."
+            "huggingface_tokenizer.encode(texts, add_special_tokens=False). Not affects tiktoken-base tokenizers. "
+            "This is the default behaviour, so adding this option has no effect, for backward compatibility only. "
+            "Not compatible with --add-special-tokens."
         ),
     )
-    parser.add_argument(
+    skip_special_group = parser.add_mutually_exclusive_group()
+    skip_special_group.add_argument(
+        "--not-skip-special-tokens",
+        "--not_skip_special_tokens",
+        required=False,
+        action="store_false",
+        help=(
+            "Produce detokenizer that won't skip special tokens during decoding, similar to "
+            "huggingface_tokenizer.decode(token_ids, skip_special_tokens=False)."
+            "Not compatible with --skip-special-tokens."
+        ),
+    )
+    skip_special_group.add_argument(
         "--skip-special-tokens",
         "--skip_special_tokens",
         required=False,
         action="store_true",
+        default=True,
         help=(
             "Produce detokenizer that will skip special tokens during decoding, similar to "
-            "huggingface_tokenizer.decode(token_ids, skip_special_tokens=True)."
+            "huggingface_tokenizer.decode(token_ids, skip_special_tokens=True). "
+            "This is the default behaviour, so adding this option has no effect, for backward compatibility only. "
+            "Not compatible with --not-skip-special-tokens."
         ),
     )
     parser.add_argument(
@@ -167,8 +197,8 @@ def convert_hf_tokenizer() -> None:
     converted = convert_tokenizer(
         hf_tokenizer,
         with_detokenizer=args.with_detokenizer,
-        skip_special_tokens=args.skip_special_tokens,
-        add_special_tokens=args.not_add_special_tokens,
+        skip_special_tokens=args.not_skip_special_tokens,
+        add_special_tokens=args.add_special_tokens,
         clean_up_tokenization_spaces=args.clean_up_tokenization_spaces,
         tokenizer_output_type=args.tokenizer_output_type,
         detokenizer_input_type=args.detokenizer_input_type,

--- a/python/openvino_tokenizers/cli.py
+++ b/python/openvino_tokenizers/cli.py
@@ -58,29 +58,14 @@ def get_parser() -> ArgumentParser:
             "Example: `convert_tokenizer SimianLuo/LCM_Dreamshaper_v7 --subfolder tokenizer`"
         ),
     )
-    special_tokens_group = parser.add_mutually_exclusive_group()
-    special_tokens_group.add_argument(
-        "--add-special-tokens",
-        "--add_special_tokens",
-        required=False,
-        action="store_true",
-        help=(
-            "Tokenizer will add special tokens during tokenization, similar to "
-            "huggingface_tokenizer.encode(texts, add_special_tokens=True). Not affects tiktoken-base tokenizers. "
-            "Not compatible with --not-add-special-tokens."
-        ),
-    )
-    special_tokens_group.add_argument(
+    parser.add_argument(
         "--not-add-special-tokens",
         "--not_add_special_tokens",
         required=False,
         action="store_false",
-        default=False,
         help=(
             "Tokenizer won't add special tokens during tokenization, similar to "
-            "huggingface_tokenizer.encode(texts, add_special_tokens=False). Not affects tiktoken-base tokenizers. "
-            "This is the default behaviour, so adding this option has no effect, for backward compatibility only. "
-            "Not compatible with --add-special-tokens."
+            "huggingface_tokenizer.encode(texts, add_special_tokens=False). Not affects tiktoken-base tokenizers."
         ),
     )
     skip_special_group = parser.add_mutually_exclusive_group()
@@ -198,7 +183,7 @@ def convert_hf_tokenizer() -> None:
         hf_tokenizer,
         with_detokenizer=args.with_detokenizer,
         skip_special_tokens=args.not_skip_special_tokens,
-        add_special_tokens=args.add_special_tokens,
+        add_special_tokens=args.not_add_special_tokens,
         clean_up_tokenization_spaces=args.clean_up_tokenization_spaces,
         tokenizer_output_type=args.tokenizer_output_type,
         detokenizer_input_type=args.detokenizer_input_type,

--- a/python/openvino_tokenizers/convert_tokenizer.py
+++ b/python/openvino_tokenizers/convert_tokenizer.py
@@ -18,13 +18,14 @@ logger = logging.getLogger(__name__)
 def convert_tokenizer(
     tokenizer_object: Any,
     with_detokenizer: bool = False,
-    add_special_tokens: bool = True,
-    skip_special_tokens: bool = False,
+    add_special_tokens: bool = False,
+    skip_special_tokens: bool = True,
     clean_up_tokenization_spaces: Optional[bool] = None,
     tokenizer_output_type: Type = Type.i64,
     detokenizer_input_type: Type = Type.i64,
     streaming_detokenizer: bool = False,
 ) -> Union[Model, Tuple[Model, Model]]:
+    print(add_special_tokens, skip_special_tokens)
     ov_tokenizers = None
 
     if "transformers" in sys.modules:

--- a/python/openvino_tokenizers/convert_tokenizer.py
+++ b/python/openvino_tokenizers/convert_tokenizer.py
@@ -25,7 +25,6 @@ def convert_tokenizer(
     detokenizer_input_type: Type = Type.i64,
     streaming_detokenizer: bool = False,
 ) -> Union[Model, Tuple[Model, Model]]:
-    print(add_special_tokens, skip_special_tokens)
     ov_tokenizers = None
 
     if "transformers" in sys.modules:

--- a/python/openvino_tokenizers/convert_tokenizer.py
+++ b/python/openvino_tokenizers/convert_tokenizer.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 def convert_tokenizer(
     tokenizer_object: Any,
     with_detokenizer: bool = False,
-    add_special_tokens: bool = False,
+    add_special_tokens: bool = True,
     skip_special_tokens: bool = True,
     clean_up_tokenization_spaces: Optional[bool] = None,
     tokenizer_output_type: Type = Type.i64,


### PR DESCRIPTION
Changes made in both CLI and API. API changes will directly affect how optimum-intel converts tokenizers as it doesn't override defaults. Keep old options for the CLI part for backward compatibility.