### PR TITLE
Configure cmake similar to GenAI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,11 @@ endif()
 
 project(openvino_tokenizers)
 
+option(CPACK_INCLUDE_TOPLEVEL_DIRECTORY "Boolean toggle to include/exclude top level directory." OFF)
+if(WIN32)
+    set(CPACK_GENERATOR "ZIP" CACHE STRING "List of CPack generators to use.")
+endif()
+
 include(cmake/platforms.cmake)
 
 # Find OpenVINODeveloperPackage first to compile with SDL flags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,8 @@ endif()
 
 project(openvino_tokenizers)
 
-option(CPACK_INCLUDE_TOPLEVEL_DIRECTORY "Boolean toggle to include/exclude top level directory." OFF)
+# Uniform outcome in all repos - all repos will not create top level directory
+set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY OFF)
 if(WIN32)
     set(CPACK_GENERATOR "ZIP" CACHE STRING "List of CPack generators to use.")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -290,6 +290,13 @@ endif()
 # Set install RPATH
 #
 
+if(SKBUILD)
+  # RPATH for wheel is mandatory to find core_tokenizers library. It
+  # must be forced because tokenizers may be built with OpenVINO targeting
+  # archive. Such OpenVINO configurations sets
+  # CMAKE_SKIP_INSTALL_RPATH to ON because it relyes on setupvars.sh.
+  set(CMAKE_SKIP_INSTALL_RPATH OFF)
+endif()
 # setting RPATH / LC_RPATH depending on platform
 if(LINUX)
   # to find libcore_tokenizer.so in the same folder
@@ -359,6 +366,5 @@ endif()
 
 set(CPACK_PACKAGE_NAME ${TARGET_NAME})
 set(CPACK_PACKAGE_VERSION "${CMAKE_PROJECT_VERSION}")
-set(CPACK_SOURCE_GENERATOR "") # not used
 
 include (CPack)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -290,13 +290,6 @@ endif()
 # Set install RPATH
 #
 
-if(SKBUILD)
-  # RPATH for wheel is mandatory to find core_tokenizers library. It
-  # must be forced because tokenizers may be built with OpenVINO targeting
-  # archive. Such OpenVINO configurations sets
-  # CMAKE_SKIP_INSTALL_RPATH to ON because it relyes on setupvars.sh.
-  set(CMAKE_SKIP_INSTALL_RPATH OFF)
-endif()
 # setting RPATH / LC_RPATH depending on platform
 if(LINUX)
   # to find libcore_tokenizer.so in the same folder


### PR DESCRIPTION
Compiling GenAI with OpenVINO from sources sets `CMAKE_SKIP_INSTALL_RPATH` to `ON`. I can’t reproduce it for openvino_tokenizers. `RUNPATH` exists in `objdump -x openvino_tokenizers/lib/libopenvino_tokenizers.so | grep 'R.*PATH'` while compiling everything from sources. `RUNPATH` is there in the wheel as well produced by CI. It’s only missing from the archive, which is fine because of setupvars. I can’t find why `RUNPATH` is set for openvino_tokenizers, but forcing `CMAKE_SKIP_INSTALL_RPATH` to `OFF` won’t harm anyway.