### PR TITLE
Support build from OpenVINO wheel only

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -236,11 +236,6 @@ jobs:
       - name: Install build dependencies
         run: sudo ${{ env.OPENVINO_REPO }}/install_build_dependencies.sh
 
-      - name: Install OpenVINO Python wheels
-        run: |
-          # Install the core OV wheel
-          python3 -m pip install ${INSTALL_DIR}/tools/openvino-*.whl
-
       #
       # Build
       #
@@ -250,6 +245,7 @@ jobs:
           source ${INSTALL_DIR}/setupvars.sh
           python -m pip wheel -v --no-deps --wheel-dir ${BUILD_DIR} \
               --config-settings=override=cross.arch="manylinux_2_31_x86_64" \
+              --find-links ${INSTALL_DIR}/tools \
               ${OPENVINO_TOKENIZERS_REPO}
         env:
           CMAKE_BUILD_PARALLEL_LEVEL: '4'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -236,6 +236,11 @@ jobs:
       - name: Install build dependencies
         run: sudo ${{ env.OPENVINO_REPO }}/install_build_dependencies.sh
 
+      - name: Install OpenVINO Python wheels
+        run: |
+          # Install the core OV wheel
+          python3 -m pip install ${INSTALL_DIR}/tools/openvino-*.whl
+
       #
       # Build
       #

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -227,6 +227,11 @@ jobs:
       - name: Install build dependencies
         run: brew install coreutils ninja
 
+      - name: Install OpenVINO Python wheels
+        run: |
+          # Install the core OV wheel
+          python3 -m pip install ${INSTALL_DIR}/tools/openvino-*.whl
+
       #
       # Build
       #

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -227,11 +227,6 @@ jobs:
       - name: Install build dependencies
         run: brew install coreutils ninja
 
-      - name: Install OpenVINO Python wheels
-        run: |
-          # Install the core OV wheel
-          python3 -m pip install ${INSTALL_DIR}/tools/openvino-*.whl
-
       #
       # Build
       #
@@ -241,6 +236,7 @@ jobs:
           source ${INSTALL_DIR}/setupvars.sh
           python3 -m pip wheel -v --no-deps --wheel-dir ${BUILD_DIR} \
               --config-settings=override=cross.arch="macosx_10_12_x86_64" \
+              --find-links ${INSTALL_DIR}/tools \
               ${OPENVINO_TOKENIZERS_REPO}
         env:
           CMAKE_BUILD_PARALLEL_LEVEL: '4'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -236,7 +236,7 @@ jobs:
       - name: Build tokenizers wheel
         run: |
           . "${{ env.INSTALL_DIR }}/setupvars.ps1"
-          python -m pip wheel -v --no-deps --find-links ${env:INSTALL_DIR }/tools --wheel-dir ${env:BUILD_DIR} ${env:OPENVINO_TOKENIZERS_REPO}
+          python -m pip wheel -v --no-deps --find-links ${env:INSTALL_DIR}/tools --wheel-dir ${env:BUILD_DIR} ${env:OPENVINO_TOKENIZERS_REPO}
         env:
           CMAKE_BUILD_PARALLEL_LEVEL: '4'
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -230,22 +230,13 @@ jobs:
           popd
 
       #
-      # Dependencies
-      #
-
-      - name: Install OpenVINO Python wheels
-        run: |
-          # Install the core OV wheel
-          python -m pip install ${{ env.INSTALL_DIR }}/tools/openvino-*.whl
-
-      #
       # Build
       #
 
       - name: Build tokenizers wheel
         run: |
           . "${{ env.INSTALL_DIR }}/setupvars.ps1"
-          python -m pip wheel -v --no-deps --wheel-dir ${env:BUILD_DIR} ${env:OPENVINO_TOKENIZERS_REPO}
+          python -m pip wheel -v --no-deps --find-links ${env:INSTALL_DIR }/tools --wheel-dir ${env:BUILD_DIR} ${env:OPENVINO_TOKENIZERS_REPO}
         env:
           CMAKE_BUILD_PARALLEL_LEVEL: '4'
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -230,6 +230,15 @@ jobs:
           popd
 
       #
+      # Dependencies
+      #
+
+      - name: Install OpenVINO Python wheels
+        run: |
+          # Install the core OV wheel
+          python -m pip install ${{ env.INSTALL_DIR }}/tools/openvino-*.whl
+
+      #
       # Build
       #
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,19 @@ project(openvino_tokenizers
 
 include(cmake/platforms.cmake)
 
+# Looking for OpenVINO in the python distribution
+find_package(Python3 REQUIRED)
+execute_process(
+    COMMAND ${Python3_EXECUTABLE} -c "from openvino.utils import get_cmake_path; print(get_cmake_path(), end='')"
+    RESULT_VARIABLE result
+    OUTPUT_VARIABLE OpenVINO_DIR_PY
+    ERROR_QUIET
+)
+if(OpenVINO_DIR_PY AND NOT OpenVINO_DIR)
+    message(STATUS "Use OpenVINO from python package: ${OpenVINO_DIR_PY}")
+    set(OpenVINO_DIR ${OpenVINO_DIR_PY} CACHE PATH "" FORCE)
+endif()
+
 # Find OpenVINODeveloperPackage first to compile with SDL flags
 find_package(OpenVINODeveloperPackage QUIET
              PATHS "${OpenVINO_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,20 +31,14 @@ include(cmake/platforms.cmake)
 find_package(Python3 REQUIRED)
 execute_process(
     COMMAND ${Python3_EXECUTABLE} -c "from openvino.utils import get_cmake_path; print(get_cmake_path(), end='')"
-    RESULT_VARIABLE result
     OUTPUT_VARIABLE OpenVINO_DIR_PY
     ERROR_QUIET
 )
-if(OpenVINO_DIR_PY AND NOT OpenVINO_DIR)
-    message(STATUS "Use OpenVINO from python package: ${OpenVINO_DIR_PY}")
-    set(OpenVINO_DIR ${OpenVINO_DIR_PY} CACHE PATH "" FORCE)
-endif()
 
 # Find OpenVINODeveloperPackage first to compile with SDL flags
-find_package(OpenVINODeveloperPackage QUIET
-             PATHS "${OpenVINO_DIR}")
+find_package(OpenVINODeveloperPackage QUIET PATHS "${OpenVINO_DIR}")
 if(NOT OpenVINODeveloperPackage_FOUND)
-    find_package(OpenVINO REQUIRED COMPONENTS Runtime OPTIONAL_COMPONENTS TensorFlow)
+    find_package(OpenVINO REQUIRED COMPONENTS Runtime OPTIONAL_COMPONENTS TensorFlow PATHS "${OpenVINO_DIR_PY}")
 endif()
 
 if(DEFINED PY_BUILD_CMAKE_PACKAGE_VERSION AND NOT PY_BUILD_CMAKE_PACKAGE_VERSION EQUAL CMAKE_PROJECT_VERSION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,13 +27,15 @@ project(openvino_tokenizers
 
 include(cmake/platforms.cmake)
 
-# Looking for OpenVINO in the python distribution
-find_package(Python3 REQUIRED)
-execute_process(
-    COMMAND ${Python3_EXECUTABLE} -c "from openvino.utils import get_cmake_path; print(get_cmake_path(), end='')"
-    OUTPUT_VARIABLE OpenVINO_DIR_PY
-    ERROR_QUIET
-)
+# Looking for OpenVINO in the python distribution. It doesn't work for cross-compiling build
+if(NOT CMAKE_CROSSCOMPILING)
+    find_package(Python3 REQUIRED)
+    execute_process(
+        COMMAND ${Python3_EXECUTABLE} -c "from openvino.utils import get_cmake_path; print(get_cmake_path(), end='')"
+        OUTPUT_VARIABLE OpenVINO_DIR_PY
+        ERROR_QUIET
+    )
+endif()
 
 # Find OpenVINODeveloperPackage first to compile with SDL flags
 find_package(OpenVINODeveloperPackage QUIET PATHS "${OpenVINO_DIR}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ python_abi = "none"
 [build-system]
 requires = [
     "py-build-cmake@git+https://github.com/tttapa/py-build-cmake@7ab73da351c7140f06d727a8705bece4cf544cd9",
-    "cmake~=3.15"
+    "cmake~=3.15",
+    "openvino~=2024.3.0.0.dev"
 ]
 build-backend = "py_build_cmake.build"


### PR DESCRIPTION
OpenVINO wheels will include cmake configurations and headers (see https://github.com/openvinotoolkit/openvino/pull/25036), after that we would be able to build extensions without downloading of OpenVINO tarballs at all