### PR TITLE
Configure cmake similar to GenAI (#175)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -375,6 +375,7 @@ install(FILES "${openvino_tokenizers_BINARY_DIR}/python/__version__.py"
 # Cpack configuration
 #
 
-set(CPACK_SOURCE_GENERATOR "") # not used
+# Uniform outcome in all repos - all repos will not create top level directory
+set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY OFF)
 
 include (CPack)


### PR DESCRIPTION
* Configure cmake similar to GenAI

Compiling GenAI with OpenVINO from sources sets `CMAKE_SKIP_INSTALL_RPATH` to `ON`. I can’t reproduce it for openvino_tokenizers. `RUNPATH` exists in `objdump -x openvino_tokenizers/lib/libopenvino_tokenizers.so | grep 'R.*PATH'` while compiling everything from sources. `RUNPATH` is there in the wheel as well produced by CI. It’s only missing from the archive, which is fine because of setupvars. I can’t find why `RUNPATH` is set for openvino_tokenizers, but forcing `CMAKE_SKIP_INSTALL_RPATH` to `OFF` won’t harm anyway.

* option->set, remove needless CMAKE_SKIP_INSTALL_RPATH