### PR TITLE
Fix segfault in PCRE2

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -230,8 +230,6 @@ PCRE2Wrapper::PCRE2Wrapper(const absl::string_view& pattern) {
         std::cerr << "PCRE2 compilation failed at offset " << erroroffset << ": " << buffer << std::endl;
         return;
     }
-
-    m_match_data = pcre2_match_data_create_from_pattern(m_compiled, NULL);
 }
 
 PCRE2Wrapper::~PCRE2Wrapper() {
@@ -239,15 +237,12 @@ PCRE2Wrapper::~PCRE2Wrapper() {
         pcre2_code_free(m_compiled);
         m_compiled = nullptr;
     }
-    if (m_match_data != nullptr) {
-        pcre2_match_data_free(m_match_data);
-        m_match_data = nullptr;
-    }
 }
 
 std::string PCRE2Wrapper::substitute(const std::string& orig_str, 
                                      const absl::string_view& replace_pattern,
                                      bool global_replace) {
+    pcre2_match_data* match_data = pcre2_match_data_create_from_pattern(m_compiled, NULL);
     PCRE2_SIZE subject_length = orig_str.size();
     
     // Usually found pattern is replaced by shorter string, but set 3 times more space for safety.
@@ -261,7 +256,7 @@ std::string PCRE2Wrapper::substitute(const std::string& orig_str,
         (PCRE2_SPTR) orig_str.c_str(), subject_length,
         0,
         0,
-        m_match_data,
+        match_data,
         NULL
     );
     if (match_result < 0 || match_result == PCRE2_ERROR_NOMATCH) {
@@ -273,7 +268,7 @@ std::string PCRE2Wrapper::substitute(const std::string& orig_str,
         (PCRE2_SPTR) orig_str.c_str(), orig_str.size(),
         0,
         global_replace ? PCRE2_SUBSTITUTE_GLOBAL : 0,
-        m_match_data,
+        match_data,
         NULL,
         (PCRE2_SPTR) replace_pattern.data(), replace_pattern.size(),
         buffer,
@@ -290,10 +285,13 @@ std::string PCRE2Wrapper::substitute(const std::string& orig_str,
     }
     auto res = std::string(reinterpret_cast<char*>(buffer), subject_length);
     std::free(buffer);
+    pcre2_match_data_free(match_data);
     return res;
 }
 
 std::pair<size_t, size_t> PCRE2Wrapper::match(const std::string& str, size_t curr_start) {
+    pcre2_match_data* match_data = pcre2_match_data_create_from_pattern(m_compiled, NULL);
+
     PCRE2_SIZE subject_length = str.length();
 
     int match_result = pcre2_match(
@@ -301,7 +299,7 @@ std::pair<size_t, size_t> PCRE2Wrapper::match(const std::string& str, size_t cur
         (PCRE2_SPTR) str.c_str(), subject_length,
         curr_start,
         0,
-        m_match_data,
+        match_data,
         NULL
     );
 
@@ -310,6 +308,7 @@ std::pair<size_t, size_t> PCRE2Wrapper::match(const std::string& str, size_t cur
     }
     // If we survived the previous IF the is at least one match,
     // not out of bound can happen here.
-    PCRE2_SIZE *ovector = pcre2_get_ovector_pointer(m_match_data);
+    PCRE2_SIZE *ovector = pcre2_get_ovector_pointer(match_data);
+    pcre2_match_data_free(match_data);
     return {ovector[0], ovector[1]};
 }

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -75,7 +75,6 @@ void set_node_name(const std::string& node_name, const std::shared_ptr<ov::Node>
 class PCRE2Wrapper {
 public:
     pcre2_code* m_compiled = nullptr;
-    pcre2_match_data* m_match_data = nullptr;
     PCRE2Wrapper(const absl::string_view& pattern);
     std::string substitute(const std::string& orig_str, const absl::string_view& replace_pattern, bool global_replace);
     std::pair<size_t, size_t> match(const std::string& orig_str, size_t curr_start);


### PR DESCRIPTION
`match_data` contains data unique for inputs string and should be allocated individually for each thread and evaluate instance.

Ticket: CVS-149376