### PR TITLE
Fix infinite loop in split for empty split_pattern

### DIFF
--- a/src/regex_split.cpp
+++ b/src/regex_split.cpp
@@ -138,7 +138,7 @@ bool RegexSplit::evaluate(ov::TensorVector& outputs, const ov::TensorVector& inp
             bool flag = this->m_search_pattern_re2->Match(str, curr_start, str.length(), RE2::UNANCHORED, &result, 1);
             if (flag) {
                 size_t start = result.data() - str.data();
-                size_t end = curr_start + result.length();
+                size_t end = start + result.length();
                 if (start != end) {
                     return std::pair(start, end);
                 }


### PR DESCRIPTION
When split pattern is empty both RE2 and PCRE2 `get_next_match` return matching `curr_begin` and `curr_end` and enter infinite loop since `start` was not incremented. Need to exit cycle when that happens.