### PR TITLE
use fields instead of __match_args__

### DIFF
--- a/python/openvino_tokenizers/convert_tokenizer.py
+++ b/python/openvino_tokenizers/convert_tokenizer.py
@@ -2,11 +2,11 @@
 # Copyright (C) 2018-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+from dataclasses import fields
 import logging
 import sys
 from typing import Any, Optional, Tuple, Union
 from functools import wraps
-
 from openvino.runtime import Model, Type
 from openvino.runtime.exceptions import OVTypeError
 
@@ -32,7 +32,7 @@ def capture_arg(func):
             params = kwargs['params']
         
         if params is not None:
-            for key in TokenzierConversionParams.__match_args__:
+            for key in fields(TokenzierConversionParams):
                 if kwargs.get(key) is not None:
                     msg = (
                         "Cannot specify both 'params' and individual convert_tokenizer arguments simultaneously. "

--- a/python/openvino_tokenizers/convert_tokenizer.py
+++ b/python/openvino_tokenizers/convert_tokenizer.py
@@ -33,7 +33,7 @@ def capture_arg(func):
         
         if params is not None:
             for key in fields(TokenzierConversionParams):
-                if kwargs.get(key) is not None:
+                if kwargs.get(key.name) is not None:
                     msg = (
                         "Cannot specify both 'params' and individual convert_tokenizer arguments simultaneously. "
                         "Please pass all conversion params either individually, e.g. "

--- a/python/openvino_tokenizers/utils.py
+++ b/python/openvino_tokenizers/utils.py
@@ -233,7 +233,7 @@ def update_rt_info(
     for key in fields(params):
         v = getattr(params, key.name)
         v = str(v) if isinstance(v, bool) else v
-        ov_tokenizer.set_rt_info(v, key)
+        ov_tokenizer.set_rt_info(v, key.name)
 
     for rt_field_name, hf_attributes in rt_info_to_hf_attribute_map.items():
         attribute = get_hf_tokenizer_attribute(hf_tokenizer, hf_attributes)

--- a/python/openvino_tokenizers/utils.py
+++ b/python/openvino_tokenizers/utils.py
@@ -231,7 +231,7 @@ def update_rt_info(
     ov_tokenizer.set_rt_info(str(type(hf_tokenizer)), ORIGINAL_TOKENIZER_CLASS_NAME)
 
     for key in fields(params):
-        v = getattr(params, key)
+        v = getattr(params, key.name)
         v = str(v) if isinstance(v, bool) else v
         ov_tokenizer.set_rt_info(v, key)
 

--- a/python/openvino_tokenizers/utils.py
+++ b/python/openvino_tokenizers/utils.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Optional, Sequence, Tuple, Union
 from openvino import Model, Type
 from openvino.preprocess import PrePostProcessor
 from openvino.runtime import opset12 as opset
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 
 from .constants import (
     LOGITS_OUTPUT_NAME,
@@ -230,7 +230,7 @@ def update_rt_info(
 ) -> None:
     ov_tokenizer.set_rt_info(str(type(hf_tokenizer)), ORIGINAL_TOKENIZER_CLASS_NAME)
 
-    for key in params.__match_args__:
+    for key in fields(params):
         v = getattr(params, key)
         v = str(v) if isinstance(v, bool) else v
         ov_tokenizer.set_rt_info(v, key)

--- a/tests/tokenizers_test.py
+++ b/tests/tokenizers_test.py
@@ -915,7 +915,7 @@ def test_rt_info_conversion_params(tokenizer_to_check_rt_info):
         ov_tokenizer = (ov_tokenizer, )
     
     for model in ov_tokenizer:
-        for key in conversion_params.__match_args__:
+        for key in fields(conversion_params):
             val = getattr(conversion_params, key)
             if val is None:
                 val = {}

--- a/tests/tokenizers_test.py
+++ b/tests/tokenizers_test.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2018-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+from dataclasses import fields
 import difflib
 import os
 import sys
-from typing import Any, Dict, List, Optional, Tuple, Union
-
 import numpy as np
 import pytest
 import requests
@@ -15,7 +14,7 @@ from openvino_tokenizers.constants import ORIGINAL_TOKENIZER_CLASS_NAME, rt_info
 from openvino_tokenizers.utils import get_hf_tokenizer_attribute, TokenzierConversionParams
 from tokenizers.models import Unigram
 from transformers import AutoTokenizer
-
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 if os.environ.get("OV_TOKENIZERS_TESTS_PRINT_WHOLE_DIFF"):
     np.set_printoptions(threshold=sys.maxsize)

--- a/tests/tokenizers_test.py
+++ b/tests/tokenizers_test.py
@@ -926,4 +926,4 @@ def test_rt_info_conversion_params(tokenizer_to_check_rt_info):
                 pass
             else:
                 val = str(val)
-            assert val == model.get_rt_info(key).value
+            assert val == model.get_rt_info(key.name).value

--- a/tests/tokenizers_test.py
+++ b/tests/tokenizers_test.py
@@ -916,7 +916,7 @@ def test_rt_info_conversion_params(tokenizer_to_check_rt_info):
     
     for model in ov_tokenizer:
         for key in fields(conversion_params):
-            val = getattr(conversion_params, key)
+            val = getattr(conversion_params, key.name)
             if val is None:
                 val = {}
             elif isinstance(val, (Type, int)) and not isinstance(val, bool):


### PR DESCRIPTION
Follow up for CVS-146675. Python <= 3.9 does not have __match_args__, use fields instead.