### PR TITLE
fix "Fix Split Mode Names #269" degradation

### DIFF
--- a/python/openvino_tokenizers/tokenizer_pipeline.py
+++ b/python/openvino_tokenizers/tokenizer_pipeline.py
@@ -554,9 +554,10 @@ class BPETokenizationStep(TokenizationModelStep):
         if self.added_tokens is None:
             return
 
-        size_diff = max(self.added_tokens.values()) - len(self.vocab) + 1
-        if size_diff > 0:
-            self.vocab.extend(type(self.vocab[0])() for _ in range(size_diff))
+        if len(self.added_tokens.values()) > 0:
+            size_diff = max(self.added_tokens.values()) - len(self.vocab) + 1
+            if size_diff > 0:
+                self.vocab.extend(type(self.vocab[0])() for _ in range(size_diff))
 
         for token, idx in self.added_tokens.items():
             if isinstance(self.vocab[0], bytes) and not isinstance(token, bytes):


### PR DESCRIPTION
There was a degradation introduced in https://github.com/openvinotoolkit/openvino_tokenizers/pull/269 
![image](https://github.com/user-attachments/assets/553efc30-bf7d-4929-befe-64647097526c)


which prevents from upgrading genai to the latest tokenizers https://github.com/openvinotoolkit/openvino.genai/pull/953