### PR TITLE
Use PCRE2 Compatible Regex Pattern

### DIFF
--- a/src/regex_normalization.cpp
+++ b/src/regex_normalization.cpp
@@ -18,7 +18,6 @@ namespace {
  * @return std::string Reformatted replace pattern
  */
 std::string reformat_replace_pattern(std::string replace_pattern) {
-//    return replace_pattern;
     return std::regex_replace(replace_pattern, std::regex(R"((\\)([0-9]+))"), R"($$2)");
 
 }


### PR DESCRIPTION
CVS-155983

Reformat normalization replace pattern to be compatible with PCRE2 for backward compatibility.