### PR TITLE
[JS] Adopt cmake config for cpack generator = npm

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -457,7 +457,7 @@ endif()
 if(CPACK_GENERATOR STREQUAL "NPM")
   set(OPENVINO_TOKENIZERS_INSTALL_LIBDIR .)
   set(OPENVINO_TOKENIZERS_INSTALL_BINDIR .)
-elseif()
+else()
   # - Windows: `<openvino_dir>\runtime\bin\intel64\Release\`
   # - MacOS_x86: `<openvino_dir>/runtime/lib/intel64/Release`
   # - MacOS_arm64: `<openvino_dir>/runtime/lib/arm64/Release/`

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -205,9 +205,9 @@ function(ov_tokenizers_link_sentencepiece TARGET_NAME)
       endif()
       # to propogate _GLIBCXX_USE_CXX11_ABI value
       target_compile_definitions(${sp_target} PUBLIC $<TARGET_PROPERTY:openvino::runtime,INTERFACE_COMPILE_DEFINITIONS>)
-      target_link_libraries(${TARGET_NAME} PRIVATE ${sp_target})      
+      target_link_libraries(${TARGET_NAME} PRIVATE ${sp_target})
     endforeach(sp_target sentencepiece sentencepiece_train)
-    
+
     if(ANDROID)
       # see https://github.com/protocolbuffers/protobuf/issues/2719#issuecomment-625400968
       target_link_libraries(${TARGET_NAME} PRIVATE log)
@@ -453,30 +453,37 @@ endif()
 # Installation
 #
 
-# - Windows: `<openvino_dir>\runtime\bin\intel64\Release\`
-# - MacOS_x86: `<openvino_dir>/runtime/lib/intel64/Release`
-# - MacOS_arm64: `<openvino_dir>/runtime/lib/arm64/Release/`
-# - Linux_x86: `<openvino_dir>/runtime/lib/intel64/`
-# - Linux_arm64: `<openvino_dir>/runtime/lib/aarch64/`
-string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" OPENVINO_TOKENIZERS_INSTALL_DIR)
-if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "amd64.*|x86_64.*|AMD64.*")
-  set(OPENVINO_TOKENIZERS_INSTALL_DIR intel64)
-elseif(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "^(arm64.*|aarch64.*|AARCH64.*|ARM64.*)")
-  if(APPLE)
-    set(OPENVINO_TOKENIZERS_INSTALL_DIR "arm64")
-  else()
-    set(OPENVINO_TOKENIZERS_INSTALL_DIR "aarch64")
+# Put binaries at the top level for NPM package
+if(CPACK_GENERATOR STREQUAL "NPM")
+  set(OPENVINO_TOKENIZERS_INSTALL_LIBDIR .)
+  set(OPENVINO_TOKENIZERS_INSTALL_BINDIR .)
+elseif()
+  # - Windows: `<openvino_dir>\runtime\bin\intel64\Release\`
+  # - MacOS_x86: `<openvino_dir>/runtime/lib/intel64/Release`
+  # - MacOS_arm64: `<openvino_dir>/runtime/lib/arm64/Release/`
+  # - Linux_x86: `<openvino_dir>/runtime/lib/intel64/`
+  # - Linux_arm64: `<openvino_dir>/runtime/lib/aarch64/`
+  string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" OPENVINO_TOKENIZERS_INSTALL_DIR)
+  if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "amd64.*|x86_64.*|AMD64.*")
+    set(OPENVINO_TOKENIZERS_INSTALL_DIR intel64)
+  elseif(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "^(arm64.*|aarch64.*|AARCH64.*|ARM64.*)")
+    if(APPLE)
+      set(OPENVINO_TOKENIZERS_INSTALL_DIR "arm64")
+    else()
+      set(OPENVINO_TOKENIZERS_INSTALL_DIR "aarch64")
+    endif()
+  elseif(OPENVINO_TOKENIZERS_INSTALL_DIR STREQUAL "x86_64" OR OPENVINO_TOKENIZERS_INSTALL_DIR STREQUAL "amd64"  # Windows detects Intel's 64-bit CPU as AMD64
+      OR CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64")
+    set(OPENVINO_TOKENIZERS_INSTALL_DIR intel64)
   endif()
-elseif(OPENVINO_TOKENIZERS_INSTALL_DIR STREQUAL "x86_64" OR OPENVINO_TOKENIZERS_INSTALL_DIR STREQUAL "amd64"  # Windows detects Intel's 64-bit CPU as AMD64
-    OR CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64")
-  set(OPENVINO_TOKENIZERS_INSTALL_DIR intel64)
-endif()
 
-if(WIN32 OR APPLE)
-  set(OPENVINO_TOKENIZERS_INSTALL_DIR ${OPENVINO_TOKENIZERS_INSTALL_DIR}/${BUILD_TYPE})
+  if(WIN32 OR APPLE)
+    set(OPENVINO_TOKENIZERS_INSTALL_DIR ${OPENVINO_TOKENIZERS_INSTALL_DIR}/${BUILD_TYPE})
+  endif()
+  set(OPENVINO_TOKENIZERS_INSTALL_BINDIR "runtime/bin/${OPENVINO_TOKENIZERS_INSTALL_DIR}" CACHE STRING "Destination for files installation of bin files - Windows dll")
+  set(OPENVINO_TOKENIZERS_INSTALL_LIBDIR "runtime/lib/${OPENVINO_TOKENIZERS_INSTALL_DIR}" CACHE STRING  "Destination for files installation of lib files")
+
 endif()
-set(OPENVINO_TOKENIZERS_INSTALL_BINDIR "runtime/bin/${OPENVINO_TOKENIZERS_INSTALL_DIR}" CACHE STRING "Destination for files installation of bin files - Windows dll")
-set(OPENVINO_TOKENIZERS_INSTALL_LIBDIR "runtime/lib/${OPENVINO_TOKENIZERS_INSTALL_DIR}" CACHE STRING  "Destination for files installation of lib files")
 
 # Installing the extension module
 install(TARGETS ${TARGET_NAME}


### PR DESCRIPTION
Put binaries at the top level of archive for CPack generator = npm. This needs to get archive with structure for NPM package.

Tasks:
- 157481