### PR TITLE
make skip_tokens an input for VocabDecode (parametrize detokenization/decoding)

### DIFF
--- a/python/openvino_tokenizers/tokenizer_pipeline.py
+++ b/python/openvino_tokenizers/tokenizer_pipeline.py
@@ -14,7 +14,7 @@ from itertools import groupby, islice
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
-from openvino.runtime import Model, Output, PartialShape, Type, op
+from openvino.runtime import Model, Output, PartialShape, Type, op, Shape
 from openvino.runtime import opset12 as opset
 from openvino.runtime.exceptions import OVTypeError, UserInputError
 from openvino.runtime.utils.types import as_node, make_constant_node
@@ -1025,7 +1025,8 @@ class VocabDecoderStep(DecodingStep):
         else:
             vocab_outputs = self.create_string_constant_node(self.vocab).outputs()
         input_nodes.extend(vocab_outputs)
-        return _get_factory().create("VocabDecoder", input_nodes, {"skip_tokens": self.skip_tokens}).outputs()
+        input_nodes.extend(op.Constant(Type.i32, Shape([len(self.skip_tokens)]), self.skip_tokens).outputs())
+        return _get_factory().create("VocabDecoder", input_nodes).outputs()
 
 
 @dataclass

--- a/src/vocab_decoder.hpp
+++ b/src/vocab_decoder.hpp
@@ -6,11 +6,24 @@
 #include <vector>
 #include <openvino/op/op.hpp>
 
+/**
+ * @class VocabDecoder
+ * @brief The VocabDecoder class is an OpenVINO operation that decodes vocabulary tokens.
+ *
+ * This class inherits from the ov::op::Op base class and provides functionality to decode
+ * vocabulary tokens while skipping specified tokens.
+ * @param input_data
+ * @param vocab_begins
+ * @param vocab_ends
+ * @param vocab_chars
+ * @param skip_tokens input has priority over the attribute.
+ * @param skip_tokens attribute is used only when skip_tokens input is not provided.
+ */
 class VocabDecoder : public ov::op::Op {
 public:
     OPENVINO_OP("VocabDecoder");
 
-    VocabDecoder () = default;
+    VocabDecoder () = default;    
     VocabDecoder(
         const ov::OutputVector& arguments,
         std::vector<int> skip_tokens


### PR DESCRIPTION
In order to skip/unskip special tokens at runtime need to specify them as inputs, this PR does that for VocabDecoder.

Ticket CVS-154151