### PR TITLE
[WHEEL] Set python_tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ OPENVINO_TOKENIZERS_INSTALL_BINDIR = "openvino_tokenizers/lib"
 OPENVINO_TOKENIZERS_INSTALL_LIBDIR = "openvino_tokenizers/lib"
 
 [tool.py-build-cmake.wheel]
+python_tag = ['py3']
 python_abi = "none"
 
 [build-system]


### PR DESCRIPTION
py-build-cmake incorrectly set python_tag (cpp311), should be py3