### PR TITLE
[JS] Update openvino-tokenizers-node package version to 2024.6.0-preview

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openvino-tokenizers-node",
-  "version": "2025.0.0-preview",
+  "version": "2024.6.0-preview",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openvino-tokenizers-node",
-      "version": "2025.0.0-preview",
+      "version": "2024.6.0-preview",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "os": [

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openvino-tokenizers-node",
-  "version": "2024.5.0-preview",
+  "version": "2024.6.0-preview",
   "description": "OpenVINO™ Tokenizers adds text processing operations to openvino-node package",
   "repository": {
     "url": "https://github.com/openvinotoolkit/openvino.git",
@@ -20,7 +20,7 @@
     "test": "node --test ./tests/*.test.js"
   },
   "binary": {
-    "version": "2024.5.0.0",
+    "version": "2024.6.0.0",
     "module_path": "./bin/",
     "remote_path": "./repositories/openvino_tokenizers/packages/{version}/",
     "package_name": "openvino_tokenizers_{platform}_{version}_{arch}.{extension}",
@@ -28,8 +28,16 @@
   },
   "keywords": [
     "OpenVINO",
+    "openvino",
     "tokenizers",
-    "OpenVINO tokenizers"
+    "OpenVINO tokenizers",
+    "openvino tokenizers",
+    "openvino-tokenizers",
+    "openvino-tokenizers-node",
+    "tokenization",
+    "text processing",
+    "string tensors",
+    "text tensors"
   ],
   "dependencies": {
     "adm-zip": "^0.5.16",


### PR DESCRIPTION
### Details:
- update openvino-tokenizers-node package version to 2024.6.0-preview
- extend keywords list