### PR TITLE
[JS] Update openvino-tokenizers-node package version to 2025.0.0

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openvino-tokenizers-node",
-  "version": "2024.6.0-preview",
+  "version": "2025.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openvino-tokenizers-node",
-      "version": "2024.6.0-preview",
+      "version": "2025.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "os": [
@@ -16,7 +16,7 @@
       ],
       "dependencies": {
         "adm-zip": "^0.5.16",
-        "openvino-node": "2024.6.0"
+        "openvino-node": "2025.0.0"
       }
     },
     "node_modules/adm-zip": {
@@ -230,9 +230,9 @@
       }
     },
     "node_modules/openvino-node": {
-      "version": "2024.6.0",
-      "resolved": "https://registry.npmjs.org/openvino-node/-/openvino-node-2024.6.0.tgz",
-      "integrity": "sha512-EQ0kdklsac3rfJTv6jUc9UIR0IG/YyIMOeq40+EYS0wozQ0mp4aQGBJRsT30SaEM4Ct797F9Mq+v9PjHxlJvcw==",
+      "version": "2025.0.0",
+      "resolved": "https://registry.npmjs.org/openvino-node/-/openvino-node-2025.0.0.tgz",
+      "integrity": "sha512-/dVmqKDI6Hr70RY1RJ3NxGi47HEYofywD8KgRqWcOmqhFYsp1tJz028OQobw2UJ9lqp65/pk/QCcx431BiRsKg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "os": [

--- a/js/package.json
+++ b/js/package.json
@@ -1,9 +1,9 @@
 {
   "name": "openvino-tokenizers-node",
-  "version": "2024.6.0-preview",
+  "version": "2025.0.0",
   "description": "OpenVINO™ Tokenizers adds text processing operations to openvino-node package",
   "repository": {
-    "url": "https://github.com/openvinotoolkit/openvino.git",
+    "url": "https://github.com/openvinotoolkit/openvino_tokenizers.git",
     "type": "git"
   },
   "license": "Apache-2.0",
@@ -20,7 +20,7 @@
     "test": "node --test ./tests/*.test.js"
   },
   "binary": {
-    "version": "2024.6.0.0",
+    "version": "2025.0.0.0",
     "module_path": "./bin/",
     "remote_path": "./repositories/openvino_tokenizers/packages/{version}/",
     "package_name": "openvino_tokenizers_{platform}_{version}_{arch}.{extension}",
@@ -41,6 +41,6 @@
   ],
   "dependencies": {
     "adm-zip": "^0.5.16",
-    "openvino-node": "2024.6.0"
+    "openvino-node": "2025.0.0"
   }
 }


### PR DESCRIPTION
### Details:

- update `openvino-tokenizers-node` package version to 2025.0.0