### PR TITLE
Propagate linker flags for ICU build

### DIFF
--- a/cmake/external/icu.cmake
+++ b/cmake/external/icu.cmake
@@ -79,7 +79,7 @@ set(ICU_INCLUDE_DIRS "${ICU_INSTALL_DIR}/include")
 if(NOT WIN32)
   set(ICU_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wno-deprecated-declarations")
   set(ICU_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -Wno-deprecated-declarations")
-  set(ICU_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} -ldl")
+  set(ICU_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} -l${CMAKE_DL_LIBS}")
 endif()
 
 # openvino::runtime exports _GLIBCXX_USE_CXX11_ABI=0 on CentOS7.

--- a/cmake/external/icu.cmake
+++ b/cmake/external/icu.cmake
@@ -74,11 +74,12 @@ endif()
 
 set(ICU_INCLUDE_DIRS "${ICU_INSTALL_DIR}/include")
 
-# Compile flags
+# Compile & link flags
 
 if(NOT WIN32)
   set(ICU_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wno-deprecated-declarations")
   set(ICU_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -Wno-deprecated-declarations")
+  set(ICU_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} -ldl")
 endif()
 
 # openvino::runtime exports _GLIBCXX_USE_CXX11_ABI=0 on CentOS7.
@@ -263,13 +264,15 @@ set(host_env_config
 if(APPLE)
   set(target_env_config
     CFLAGS=${ICU_C_FLAGS}
-    CXXFLAGS=${ICU_CXX_FLAGS})
+    CXXFLAGS=${ICU_CXX_FLAGS}
+    LDFLAGS=${ICU_LINKER_FLAGS})
 else()
   set(target_env_config
     CFLAGS=${ICU_C_FLAGS}
     CC=${c_prefix}${CMAKE_C_COMPILER}
     CXXFLAGS=${ICU_CXX_FLAGS}
-    CXX=${cxx_prefix}${CMAKE_CXX_COMPILER})
+    CXX=${cxx_prefix}${CMAKE_CXX_COMPILER}
+    LDFLAGS=${ICU_LINKER_FLAGS})
 
     foreach(tool IN ITEMS CMAKE_AR CMAKE_RANLIB CMAKE_STRIP CMAKE_READELF CMAKE_OBJDUMP CMAKE_OBJCOPY
                       CMAKE_NM CMAKE_DLLTOOL CMAKE_ADDR2LINE CMAKE_MAKE_PROGRAM)

--- a/cmake/external/icu.cmake
+++ b/cmake/external/icu.cmake
@@ -79,7 +79,10 @@ set(ICU_INCLUDE_DIRS "${ICU_INSTALL_DIR}/include")
 if(NOT WIN32)
   set(ICU_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wno-deprecated-declarations")
   set(ICU_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -Wno-deprecated-declarations")
-  set(ICU_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} -l${CMAKE_DL_LIBS}")
+  set(ICU_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS}")
+  if (CMAKE_DL_LIBS)
+    set(ICU_LINKER_FLAGS "${ICU_LINKER_FLAGS} -l${CMAKE_DL_LIBS}")
+  endif()
 endif()
 
 # openvino::runtime exports _GLIBCXX_USE_CXX11_ABI=0 on CentOS7.


### PR DESCRIPTION
- Propagate linker flags for ICU build
- Fix build issue with enabled sanitizer:

```
/usr/bin/ld: ../../lib/libicuuc.a(putil.ao): undefined reference to symbol 'dlsym@@GLIBC_2.2.5'
/usr/bin/ld: /lib/x86_64-linux-gnu/libdl.so.2: error adding symbols: DSO missing from command line
```