### PR TITLE
Add JiT Compilation to PCRE2

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -200,6 +200,7 @@ function(ov_tokenizers_link_pcre2 TARGET_NAME)
     set(PCRE2_BUILD_TESTS OFF)
     set(PCRE2_BUILD_PCRE2GREP OFF)
     set(PCRE2_BUILD_TESTS)
+    set(PCRE2_SUPPORT_JIT ON)
 
     add_subdirectory(${prce2_SOURCE_DIR} ${prce2_BINARY_DIR} EXCLUDE_FROM_ALL)
   endif()

--- a/src/unigram_tokenizer.hpp
+++ b/src/unigram_tokenizer.hpp
@@ -25,13 +25,12 @@ using Scores = std::vector<float>;
 
 class UnigramTokenizerImpl {
 private:
-    std::shared_ptr<Darts::DoubleArray> m_trie;
-    std::shared_ptr<unigram_impl::Scores> m_scores;
+    Darts::DoubleArray m_trie;
+    unigram_impl::Scores m_scores;
     double m_min_score;
     bool m_byte_fallback = false;
     const int m_unk_token_id = 0;
     bool m_fuse_unk = false;
-//    std::unordered_map<std::string, std::vector<int32_t>> m_cache;
 public:
     UnigramTokenizerImpl(
         unigram_impl::Vocab& vocab,

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -280,7 +280,8 @@ std::string PCRE2Wrapper::substitute(const std::string& orig_str,
     PCRE2_SIZE subject_length = orig_str.size();
     
     // Check if the string matches the pattern
-    int num_matches = pcre2_match(
+    const auto match_func = m_is_jit ? pcre2_jit_match : pcre2_match;
+    int num_matches = match_func(
         m_compiled,
         (PCRE2_SPTR) orig_str.c_str(), subject_length,
         0,

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -74,12 +74,14 @@ std::shared_ptr<ov::Node> string_attribute_to_constant (const ov::frontend::Node
 void set_node_name(const std::string& node_name, const std::shared_ptr<ov::Node>& node);
 
 class PCRE2Wrapper {
-public:
-    pcre2_code* m_compiled = nullptr;
-    PCRE2Wrapper(const absl::string_view& pattern);
-    std::string substitute(const std::string& orig_str, const absl::string_view& replace_pattern, bool global_replace);
-    std::pair<size_t, size_t> match(const std::string& orig_str, size_t curr_start);
-    ~PCRE2Wrapper();
+    public:
+        pcre2_code* m_compiled = nullptr;
+        PCRE2Wrapper(const absl::string_view& pattern);
+        std::string substitute(const std::string& orig_str, const absl::string_view& replace_pattern, bool global_replace);
+        std::pair<size_t, size_t> match(const std::string& orig_str, size_t curr_start);
+        ~PCRE2Wrapper();
+    private:
+        bool m_is_jit = 0;
 };
 
 class Trie {


### PR DESCRIPTION
- Speed up `match` and `substitute` methods of `PCRE2Wrapper`

Benchmark results (i9-10980XE):
- **Xenova/gpt-4o:**
Before:
Sync:  OV: 1041.573 FPS, HF: 1831.254 FPS, OV/HF: 0.5687758075194422
Async: OV: 6873.116 FPS, HF: 1831.254 FPS, OV/HF: 3.753229524742228
After:
Sync:  OV: 1828.426 FPS, HF: 1799.136 FPS, OV/HF: 1.0162797516004303
Async: OV: 6276.791 FPS, HF: 1799.136 FPS, OV/HF: 3.4887804039175005
- **BAAI/bge-reranker-v2-m3:**
Before:
Sync:  OV: 860.586 FPS, HF: 1503.576 FPS, OV/HF: 0.5723594732195535
Async: OV: 5459.165 FPS, HF: 1503.576 FPS, OV/HF: 3.6307875921539288
After:
Sync:  OV: 1829.828 FPS, HF: 1561.229 FPS, OV/HF: 1.1720434745361927
Async: OV: 6909.142 FPS, HF: 1561.229 FPS, OV/HF: 4.425451319526877
- **google/flan-t5-xxl:**
Before:
Sync:  OV: 1015.991 FPS, HF: 1742.299 FPS, OV/HF: 0.5831325036213919
Async: OV: 6009.998 FPS, HF: 1742.299 FPS, OV/HF: 3.4494645037061304
After:
Sync:  OV: 2003.620 FPS, HF: 1648.930 FPS, OV/HF: 1.2151027742685914
Async: OV: 6955.370 FPS, HF: 1648.930 FPS, OV/HF: 4.218110800753291
- **bert-base-uncased:**
Before:
Sync:  OV: 966.191 FPS, HF: 1796.871 FPS, OV/HF: 0.537707686934503
Async: OV: 5802.693 FPS, HF: 1796.871 FPS, OV/HF: 3.229332893522078
After:
Sync:  OV: 1798.308 FPS, HF: 1769.413 FPS, OV/HF: 1.016330446103731
Async: OV: 6848.318 FPS, HF: 1769.413 FPS, OV/HF: 3.8703909704550936

- Remove pointer from `UnigramTokenizerImpl` 