### PR TITLE
Replace openvino.runtime import

### DIFF
--- a/python/openvino_tokenizers/tokenizer_transformations.py
+++ b/python/openvino_tokenizers/tokenizer_transformations.py
@@ -9,7 +9,7 @@ import numpy as np
 import openvino as ov
 from openvino import PartialShape, Type
 from openvino import opset15 as opset
-from openvino.runtime.passes import Manager, ModelPass
+from openvino.passes import Manager, ModelPass
 from openvino.utils.types import make_constant_node
 
 


### PR DESCRIPTION
`openvino.runtime` is deprecated since `openvino 2025.0`.  
https://github.com/openvinotoolkit/openvino_tokenizers/pull/378