### PR TITLE
[GHA] Use OV provider for testing dependabot changes

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -282,7 +282,6 @@ jobs:
         uses: ./.github/actions/install_poetry
       
       - name: Find OpenVINO wheel
-        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: ./.github/actions/find_wheel
         id: ov_wheel
         with:
@@ -290,7 +289,6 @@ jobs:
           package_name: 'openvino'
              
       - name: Install OpenVINO wheel
-        if: ${{ github.actor != 'dependabot[bot]' }}
         run: poetry add ${{ steps.ov_wheel.outputs.wheel_path }}
         
       - name: Find Tokenizers wheel
@@ -362,7 +360,6 @@ jobs:
         uses: ./.github/actions/install_poetry
       
       - name: Find OpenVINO wheel
-        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: ./.github/actions/find_wheel
         id: ov_wheel
         with:
@@ -370,7 +367,6 @@ jobs:
           package_name: 'openvino'
               
       - name: Install OpenVINO wheel
-        if: ${{ github.actor != 'dependabot[bot]' }}
         run: poetry add ${{ steps.ov_wheel.outputs.wheel_path }}
 
       - name: Find Tokenizers wheel

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -309,7 +309,6 @@ jobs:
         uses: ./.github/actions/install_poetry
         
       - name: Find OpenVINO wheel
-        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: ./.github/actions/find_wheel
         id: ov_wheel
         with:
@@ -317,7 +316,6 @@ jobs:
           package_name: 'openvino'
           
       - name: Install OpenVINO wheel
-        if: ${{ github.actor != 'dependabot[bot]' }}
         run: poetry add ${{ steps.ov_wheel.outputs.wheel_path }}
 
       - name: Find Tokenizers wheel

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -371,7 +371,6 @@ jobs:
         uses: ./.github/actions/install_poetry
       
       - name: Find OpenVINO wheel
-        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: ./.github/actions/find_wheel
         id: ov_wheel
         with:
@@ -379,7 +378,6 @@ jobs:
           package_name: 'openvino'
          
       - name: Install OpenVINO wheel
-        if: ${{ github.actor != 'dependabot[bot]' }}
         run: poetry add ${{ steps.ov_wheel.outputs.wheel_path }}
       
       - name: Find Tokenizers wheel


### PR DESCRIPTION
dependabot doesn't update the nightly versions properly (it uses the oldest development version)