### PR TITLE
[ICU] Replace py -3 on windows

### DIFF
--- a/cmake/external/icu.cmake
+++ b/cmake/external/icu.cmake
@@ -195,7 +195,8 @@ function(ov_tokenizer_build_icu)
       SOURCE_DIR ${ICU_SOURCE_DIR}
       BINARY_DIR ${ARG_BUILD_DIR}
       INSTALL_DIR ${ARG_INSTALL_DIR}
-      PATCH_COMMAND powershell -Command "(Get-ChildItem -Path <SOURCE_DIR>/source -Recurse -File -Filter \"*.vcxproj\" | ForEach-Object { (Get-Content $_.FullName) -replace '<DebugInformationFormat>EditAndContinue</DebugInformationFormat>', '<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>' | Set-Content $_.FullName })"
+      PATCH_COMMAND powershell -Command "(Get-ChildItem -Path <SOURCE_DIR>/source -Recurse -File -Filter \"*.vcxproj\" | ForEach-Object { (Get-Content $_.FullName) -replace '<DebugInformationFormat>EditAndContinue</DebugInformationFormat>', '<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>' | Set-Content $_.FullName })" &&
+                    powershell -Command "(Get-ChildItem -Path <SOURCE_DIR>/source -Recurse -File -Filter \"*.mak\" | ForEach-Object { (Get-Content $_.FullName) -replace 'py\\s*-3', 'python' | Set-Content $_.FullName })"
       CONFIGURE_COMMAND ""
       BUILD_COMMAND ${CMAKE_COMMAND} -E env CL=${ICU_CXX_FLAGS} LINK=${ICU_LINKER_FLAGS} msbuild ${ICU_SOURCE_DIR}\\source\\allinone\\allinone.sln /p:Configuration=${ICU_BUILD_TYPE} /p:Platform=x64 /t:i18n /t:uconv /t:makedata
       INSTALL_COMMAND ${CMAKE_COMMAND} -E copy_directory ${ICU_SOURCE_DIR}/include ${ARG_INSTALL_DIR}/include &&
@@ -247,9 +248,9 @@ function(ov_tokenizer_build_icu)
       SOURCE_DIR ${ICU_SOURCE_DIR}
       BINARY_DIR ${ARG_BUILD_DIR}
       INSTALL_DIR ${ARG_INSTALL_DIR}
-      CONFIGURE_COMMAND ${ARG_HOST_ENV} ${ICU_SOURCE_DIR}/source/configure ${ICU_CONFIGURE_FLAGS}
-      BUILD_COMMAND make -j${ICU_JOB_POOL_SIZE}
-      INSTALL_COMMAND make install
+      CONFIGURE_COMMAND
+      BUILD_COMMAND 
+      INSTALL_COMMAND
       BUILD_BYPRODUCTS ${ICU_LIBRARIES_RELEASE} ${ICU_LIBRARIES_DEBUG})
   else()
     message(FATAL_ERROR "Unsupported platform: ${ARG_TARGET_SYSTEM_NAME}")


### PR DESCRIPTION
Simplify windows build when python installation doesn't contain "py" executable 