### PR TITLE
Allow to specify value 2 in input to pad_right

### DIFF
--- a/src/ragged_to_dense.cpp
+++ b/src/ragged_to_dense.cpp
@@ -83,11 +83,13 @@ bool RaggedToDense::evaluate(ov::TensorVector& outputs, const ov::TensorVector& 
     // which was defined during model conversion, but we don't know that value during the transformation
     // therefore we have to have a value in pad_right input which will indicate what default value from the attribute 
     // should be taken, and we decided that to be number 2.
-    int32_t pad_val_from_input = inputs[5].data<int32_t>()[0];
-    OPENVINO_ASSERT(pad_val_from_input >= 0 && pad_val_from_input <= 2,
-        "RaggedToDense: pad_right should be 0 (left), 1 (right), or 2 (use attribute).");
-    if (get_input_size() == 6 && pad_val_from_input != 2) {
-        pad_right = pad_val_from_input;
+    if (get_input_size() == 6) {
+        int32_t pad_val_from_input = inputs[5].data<int32_t>()[0];
+        OPENVINO_ASSERT(pad_val_from_input >= 0 && pad_val_from_input <= 2,
+            "RaggedToDense: pad_right should be 0 (left), 1 (right), or 2 (use attribute).");
+        if (pad_val_from_input != 2){
+            pad_right = pad_val_from_input;
+        }
     }
 
     if (pad_right) {

--- a/src/ragged_to_dense.hpp
+++ b/src/ragged_to_dense.hpp
@@ -25,7 +25,7 @@ public:
      * - data The data of the ragged tensor.
      * - padding_size The size of the padding to be applied.
      * - value The value to be used for padding.
-     * - pad_right  This input has priority over the attribute "padding_side". If true, padding is applied to the right side of the tensor.
+     * - pad_right pad_right should be 0 (left), 1 (right), or 2 (use attribute). This input has priority over the attribute unless input value is 2.
      * @param pad_right If true, padding is applied to the right side of the tensor. Default is true.
      * @param pad_max_length If true, padding is applied to the maximum length of the tensor. Default is false.
      *

--- a/tests/layer_tests.py
+++ b/tests/layer_tests.py
@@ -526,13 +526,13 @@ def test_ragged_to_dense(input_values, expected):
     np_input_values = [np.array(input_values[key], dtype=np.int32) for key in numeric_input_names]
     
     if "pad_right" in input_values:
-        np_input_values.append(np.array(input_values["pad_right"], dtype=np.bool))
+        np_input_values.append(np.array(input_values["pad_right"], dtype=np.int32))
     
 
     # Parameter for all inputs except value
     input_params = [op.Parameter(Type.i32, PartialShape(["?"])) for _ in range(len(numeric_input_names) - 1)]
     # Parameter for value
-    input_params = [*input_params, op.Parameter(Type.i32, PartialShape([])), *([op.Parameter(Type.boolean, PartialShape([]))] if "pad_right" in input_values else [])]
+    input_params = [*input_params, op.Parameter(Type.i32, PartialShape([])), *([op.Parameter(Type.i32, PartialShape([]))] if "pad_right" in input_values else [])]
 
     assert input_values["padding_side"] in ["right", "left"]
     pad_right = True if input_values["padding_side"] == "right" else False
@@ -540,7 +540,7 @@ def test_ragged_to_dense(input_values, expected):
 
     ragged_to_dense_model = Model(ragged_to_dense, input_params, "ragged_to_dense")
     compiled_model = core.compile_model(ragged_to_dense_model)
-
+    breakpoint()
     res = compiled_model(np_input_values)
     assert np.all(res[0] == np.array(expected, dtype=np.int32))
 

--- a/tests/layer_tests.py
+++ b/tests/layer_tests.py
@@ -519,6 +519,36 @@ def test_unigram_model(test_string, hf_charsmap_sentencepiece_tokenizer):
                 [30, 40, 50, 200, 300, 42, 42, 42, 42, 42],
             ],
         ),
+        (
+            {
+                "begins": [0, 3],
+                "ends": [3, 8],
+                "data": [10, 20, 100, 30, 40, 50, 200, 300],
+                "padding_size": 10,
+                "value": 42,
+                "pad_right": 2, # 2 indicates that padding side should be take from the attribute value
+                "padding_side": "right", # input value of pad_right is 2 which means that padding value is taken from this Op attribute
+            },
+            [
+                [10, 20, 100, 42, 42, 42, 42, 42, 42, 42],
+                [30, 40, 50, 200, 300, 42, 42, 42, 42, 42],
+            ],
+        ),
+        (
+            {
+                "begins": [0, 3],
+                "ends": [3, 8],
+                "data": [10, 20, 100, 30, 40, 50, 200, 300],
+                "padding_size": 10,
+                "value": 42,
+                "pad_right": 2, # 2 indicates that padding side should be take from the attribute value
+                "padding_side": "left",  # input value of pad_right is 2 which means that padding value is taken from this Op attribute
+            },
+            [
+                [42, 42, 42, 42, 42, 42, 42, 10, 20, 100],
+                [42, 42, 42, 42, 42, 30, 40, 50, 200, 300],
+            ],
+        ),
     ],
 )
 def test_ragged_to_dense(input_values, expected):
@@ -540,7 +570,7 @@ def test_ragged_to_dense(input_values, expected):
 
     ragged_to_dense_model = Model(ragged_to_dense, input_params, "ragged_to_dense")
     compiled_model = core.compile_model(ragged_to_dense_model)
-    breakpoint()
+
     res = compiled_model(np_input_values)
     assert np.all(res[0] == np.array(expected, dtype=np.int32))
 

--- a/tests/pass_rates.json
+++ b/tests/pass_rates.json
@@ -1,3 +1,4 @@
 {
-    "tests/tokenizers_test.py::test_": 0.9520427445103278
+    "tests/tokenizers_test.py::test_": 0.9520427445103278,
+    "tests/layer_tests.py::test_ragged_to_dense[input_values": 0.4
 }


### PR DESCRIPTION
- This allow to set value integer values (instead of bool) to `pad_right` input. This is necessary because if user called in ov::genai::Tokenizer` method `encode` with no padding value it should pad to the default value which is used during model conversion which is stored in the attribute, but since we don't have access to the attribute we specify by value `2` on `pad_right` input that op should rely on attribute value. See more details in the comment.
- Ticket CVS-163374