### PR TITLE
[GHA] removed unused option for the new coverity version

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Build for coverity
         run: |
           source ${INSTALL_DIR}/setupvars.sh
-          ${ENV_COV_TOOL_DIR}/bin/cov-build --config ${ENV_COV_TOOL_DIR}/config/coverity_config.xml --tmpdir cov_temp --dir ${BUILD_DIR}/cov-int --fs-capture-search ${OPENVINO_TOKENIZERS_REPO} sh build.sh
+          ${ENV_COV_TOOL_DIR}/bin/cov-build --config ${ENV_COV_TOOL_DIR}/config/coverity_config.xml --tmpdir cov_temp --dir ${BUILD_DIR}/cov-int ${OPENVINO_TOKENIZERS_REPO} sh build.sh
 
       - name: Pack for analysis submission
         run: tar -cvf - cov-int | pigz > openvino-tokenizers.tgz


### PR DESCRIPTION
the new version of the coverity util doesn't support --fs-capture-search option