### PR TITLE
[JS] Download rhel8 binaries for linux

### DIFF
--- a/js/scripts/download-runtime.js
+++ b/js/scripts/download-runtime.js
@@ -28,7 +28,7 @@ class TokenizersBinaryManager extends BinaryManager {
       case 'win32':
         return 'windows';
       case 'linux':
-        return 'centos7';
+        return 'rhel8';
       case 'darwin':
         return 'macos_12_6';
     }


### PR DESCRIPTION
Cherry-picked from #548
## Details 
- JS bindings is built on rhel8, so `openvino-tokenizer-node` should use the same binaries
## Tickets:
CVS-172595