### PR TITLE
[CI] [GHA] Remove unused argument from the `cov-build` command

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Build for coverity
         run: |
           source ${INSTALL_DIR}/setupvars.sh
-          ${ENV_COV_TOOL_DIR}/bin/cov-build --config ${ENV_COV_TOOL_DIR}/config/coverity_config.xml --tmpdir cov_temp --dir ${BUILD_DIR}/cov-int ${OPENVINO_TOKENIZERS_REPO} sh build.sh
+          ${ENV_COV_TOOL_DIR}/bin/cov-build --config ${ENV_COV_TOOL_DIR}/config/coverity_config.xml --tmpdir cov_temp --dir ${BUILD_DIR}/cov-int sh build.sh
 
       - name: Pack for analysis submission
         run: tar -cvf - cov-int | pigz > openvino-tokenizers.tgz


### PR DESCRIPTION
The `${OPENVINO_TOKENIZERS_REPO}` is interpreted as the build command: 
<img width="999" height="26" alt="image" src="https://github.com/user-attachments/assets/7da78933-54d0-44b6-b8f7-e3aad34028c6" />
