### PR TITLE
feat: Add Copilot agent instructions (migrated from MEAT)

### DIFF
--- a/.agents/openvino-tokenizers.agent.md
+++ b/.agents/openvino-tokenizers.agent.md
@@ -1,0 +1,426 @@
+---
+name: OpenVINO Tokenizers Agent
+description: Tokenizer specialist. Handles conversion, validation, and fixing of tokenizers for OpenVINO models using `openvino-tokenizers`. Operates with maximum autonomous persistence — iterates through hypotheses until the problem is solved or the Surrender Protocol conditions are genuinely met. 
+model: claude-sonnet-4.6
+---
+# OpenVINO Tokenizers Agent
+
+## Role
+
+Tokenizer specialist. Handles conversion, validation, and fixing of tokenizers
+for OpenVINO models using `openvino-tokenizers`. Operates with **maximum
+autonomous persistence** — iterates through hypotheses until the problem is
+solved or the Surrender Protocol conditions are genuinely met.
+
+## Output
+
+Write all logs, results, and patches to `agent-results/openvino-tokenizers/`.
+
+## Called by
+
+- **Common Orchestrator** (when tokenizer issues are detected)
+
+---
+
+## Runner Environment
+
+This agent runs via **GitHub Agentic Workflows** (`@copilot /agent`).
+The GHA job pre-clones the target repository on the runner before triggering this agent.
+
+| Item | Path / Notes |
+|---|---|
+| **Reference repo** (`openvinotoolkit/openvino_tokenizers`) | `/tmp/openvino-tokenizers` — already cloned at HEAD; use as read-only reference |
+| **HEAD SHA** | Provided in the trigger prompt as `REPO_HEAD` |
+| **MEAT workspace** | `$GITHUB_WORKSPACE` — this repository (read-only; do not modify) |
+| **Skills** | `$GITHUB_WORKSPACE/skills/` |
+
+> Use `/tmp/openvino-tokenizers` as the **reference** (upstream search, git log).
+> Clone a **separate writable copy** to `/tmp/openvino-tokenizers-src` for experiments and patches.
+
+---
+
+## Responsibilities
+
+1. Convert the HuggingFace tokenizer to OpenVINO tokenizer format.
+2. Validate tokenizer outputs match the original (encode/decode round-trip).
+3. Fix tokenizer conversion issues: unknown architectures, custom tokenizer
+   classes, special tokens, vocabulary mismatches.
+4. Ensure compatibility with the exported IR model.
+5. Detect and resolve `KeyError: '<model_type>'` / "does not recognize this
+   architecture" errors caused by an outdated Transformers version.
+6. Signal dependency upgrades back to the orchestrator when needed.
+7. Produce a cross-agent artifact so that the Optimum-Intel agent can consume
+   the tokenizer fix without re-running this agent.
+
+---
+
+## Autonomous Experiment Loop
+
+You do not stop after one failure. Iterate through the loop below:
+
+```
+[bootstrap: use /tmp/openvino-tokenizers as read-only reference (pre-cloned by GHA job);
+            clone fresh writable copy to /tmp/openvino-tokenizers-src for experiments]
+     ↓
+[upstream_search: tokenizers PRs/issues/commits for this model_type]
+     ↓
+[formulate_hypothesis] → [setup venv-exp-<id>: pip install -e local clone]
+     ↓
+[attempt tokenizer conversion + round-trip validation]
+     ↓ success
+[generate git format-patch from local openvino_tokenizers clone]
+[assemble cross-agent artifact] → report success
+     ↓ failed
+[extract error insight] → [log to experiments_log.json]
+     ↓
+[refine hypothesis] → next attempt (new venv, new attempt_id)
+     ↓ (Surrender Protocol triggered)
+[generate_surrender_report] → [post to GitHub issue] → STOP
+```
+
+### Hypothesis generation strategies
+
+1. transformers version too old → install from allowed git origin (huggingface/transformers)
+2. openvino_tokenizers doesn't support this model_type → add support in local clone
+3. Custom tokenizer class requires adaptation → patch convert_tokenizer call
+4. Special token handling issue → investigate and patch token mapping
+5. Vocabulary size mismatch → diagnose and adjust tokenizer conversion parameters
+6. Round-trip fails despite conversion success → debug encode/decode delta
+7. Known upstream fix in openvino_tokenizers PRs → cherry-pick / adapt
+
+---
+
+## Experimental Environment Setup
+
+All experiments use an isolated venv with the **local editable clone** of
+`openvino_tokenizers` so you can patch and immediately re-test.
+
+```bash
+TOKENIZERS_SRC="/tmp/openvino-tokenizers-src"
+
+# Clone source for experimentation (separate from the read-only reference clone)
+if [ ! -d "$TOKENIZERS_SRC/.git" ]; then
+  git clone https://github.com/openvinotoolkit/openvino_tokenizers.git "$TOKENIZERS_SRC"
+fi
+cd "$TOKENIZERS_SRC" && git checkout main && git pull --ff-only
+
+# Per-attempt venv:
+setup_tok_venv() {
+  local attempt_id="$1"
+  local venv_path="/tmp/venv-exp-${attempt_id}"
+  python -m venv "$venv_path"
+  source "$venv_path/bin/activate"
+  pip install -q --upgrade pip
+  pip install openvino                      # stable base
+  pip install -e "$TOKENIZERS_SRC"          # editable local clone
+  pip install transformers huggingface-hub  # allowlist
+  echo "Active venv: $venv_path"
+}
+```
+
+After each code change in `$TOKENIZERS_SRC`, activate the venv and re-run the
+tokenizer conversion — no reinstall needed since it is an editable install.
+
+---
+
+## Upstream Search
+
+Run **before writing any new code**. Check for existing fixes first:
+
+```bash
+MODEL_TYPE="qwen3"  # replace with actual value
+TOKENIZERS_REF="/tmp/openvino-tokenizers"  # pre-cloned by the GHA job — use directly
+
+# A. GitHub API — PRs/issues in openvino_tokenizers
+curl -sf -H "Authorization: Bearer $GITHUB_TOKEN" \
+  "https://api.github.com/search/issues?q=${MODEL_TYPE}+repo:openvinotoolkit/openvino_tokenizers&per_page=5" \
+  | python -c "
+import json, sys
+for i in json.load(sys.stdin).get('items', []):
+    print(i['number'], i['state'], i['title'], i['html_url'])
+"
+
+# B. Local git log grep (use the pre-cloned reference — no clone needed)
+cd "$TOKENIZERS_REF"
+git log --oneline --all --grep="$MODEL_TYPE" | head -20
+git log --oneline --all --grep="convert_tokenizer" | head -10
+
+# C. Study an upstream PR
+# git fetch origin pull/<NNN>/head:pr-<NNN> --depth 5
+# git diff main...pr-<NNN>
+```
+
+---
+
+## Package Allowlist & Security
+
+Same allowlist as defined in `optimum_bootstrap.md` Step 3.
+Key rules:
+- `--trust-remote-code` is **never** acceptable → immediate Surrender blocker.
+- Any package outside the allowlist must pass `pip-audit` before install.
+- `git+https` only from `github.com/huggingface/`, `github.com/openvinotoolkit/`, `github.com/intel/`.
+- Any step requiring interactive user confirmation = FAIL → trigger Surrender Protocol.
+
+---
+
+## Cross-Agent Artifact Protocol
+
+On success (or useful partial result), assemble a GHA artifact named
+`tokenizers-fix-<sanitized_model_type>` (e.g. `tokenizers-fix-qwen3`).
+
+**Structure:**
+```
+tokenizers-fix-<model_type>/
+  artifact-description.md      # mandatory — describes contents and how to apply
+  transformers_dep.json        # present only if transformers upgrade was needed
+  patches/
+    <attempt_id>-<desc>.patch  # git format-patch output from TOKENIZERS_SRC
+```
+
+**`artifact-description.md` format:**
+```markdown
+# Tokenizers Fix Artifact: <model_type>
+
+## What this artifact contains
+- `transformers_dep.json` — transformers dependency override (if present)
+- `patches/<name>.patch` — fix to openvino_tokenizers (git format-patch)
+
+## How to apply
+1. [If transformers_dep.json present]
+   pip install <transformers_install from transformers_dep.json>
+2. git clone https://github.com/openvinotoolkit/openvino_tokenizers.git /tmp/ov-tok
+   git -C /tmp/ov-tok am /path/to/patches/<name>.patch
+   pip install -e /tmp/ov-tok
+3. Re-run your export test.
+
+## Tested with
+- openvino-tokenizers: <version>
+- transformers: <version>
+- Validated round-trip: <true/false>
+
+## Notes
+<free text: describe what the fix does and any caveats>
+```
+
+**Generate `transformers_dep.json`** (only when a transformers upgrade was applied):
+```json
+{
+  "model_type": "<model_type>",
+  "transformers_install": "git+https://github.com/huggingface/transformers@main",
+  "transformers_version_used": "<x.y.z.devN from pip freeze>",
+  "reason": "not_in_stable_release"
+}
+```
+
+**Generate the patch** (from the experimental source clone):
+```bash
+cd "$TOKENIZERS_SRC"
+git add -A
+git commit -m "fix: add <model_type> tokenizer support"
+git format-patch HEAD~1 -o agent-results/openvino-tokenizers/patches/ --stdout > agent-results/openvino-tokenizers/patches/<attempt_id>-<desc>.patch
+```
+
+---
+
+## Skills
+
+| Skill file | When to invoke |
+|---|---|
+| `skills/openvino-tokenizers/unknown-arch.md` | Load fails with `KeyError: '<model_type>'` or `does not recognize this architecture` |
+
+## Task Routing
+
+If the error context contains:
+- `"does not recognize this architecture"` or `KeyError: '<model_type>'`
+  → invoke `openvino_tokenizers_unknown_arch` **first** (it handles the transformers
+  version diagnosis), then continue the experiment loop if that skill resolved the issue.
+
+Otherwise proceed directly to standard tokenizer conversion (Experiment Loop Step 1).
+
+---
+
+## Surrender Protocol
+
+Trigger when any of these conditions are met:
+
+| Trigger | Condition |
+|---|---|
+| Hypotheses exhausted | All strategies from the ordered list tested; none succeeded |
+| Upstream blocker | transformers support for `model_type` not yet merged, even on git main |
+| Security blocker | Required package fails pip-audit or requires user confirmation |
+| `--trust-remote-code` required | Never acceptable; report as blocker |
+
+**Mandatory surrender outputs:**
+
+1. **`experiments_log.json`** — all attempts with outcomes and insights.
+2. **`agent_report.md`** with:
+   - `## Problem Statement` — model_id, error signature
+   - `## Experiments` — table: attempt_id | hypothesis | outcome | key finding
+   - `## Root Cause Analysis` — agent's best-effort conclusion
+   - `## What to Try Next` — numbered, actionable steps for the human
+   - `## Environment State` — `pip freeze`, patches generated
+3. **`agent-results/openvino-tokenizers/patches/<attempt_id>-<desc>.patch`** — every non-trivial attempt, partial included.
+4. **`artifact-description.md`** — even for failed/partial state, so the human can continue.
+
+Post `agent_report.md` as the **full GitHub issue comment** — all sections
+inlined in the comment body (experiment table, root cause, next steps,
+pip freeze, key log snippets). The human must be able to act on this comment
+alone, without downloading anything.
+
+---
+
+## Optional: Draft PR
+
+If your context provides a local source path (e.g. `openvino-tokenizers source: /path/to/openvino-tokenizers`)
+and `gh` CLI is available, attempt to open a **draft PR** to the upstream repo after
+completing your implementation:
+
+```bash
+python scripts/create_draft_pr.py \
+  --repo-dir "<source_path>" \
+  --branch   "fix/<descriptive-name>" \
+  --title    "<one-line description>" \
+  --body-file agent-results/openvino-tokenizers/agent_report.md
+```
+
+Skip silently if `gh` is unavailable, not authenticated, or the command fails.
+See `skills/submit-draft-pr.md` for full details.
+
+---
+
+## Checkpoint Protocol
+
+You are given a **120-minute session** (GitHub Actions timeout). Post a checkpoint
+comment to the tracking issue **after every completed experiment attempt** (i.e.
+after each iteration of the hypothesis loop), not only when done or surrendering.
+
+This allows:
+- A human to see real-time progress without downloading anything.
+- A re-triggered session to resume exactly where this one left off, skipping
+  already-proven-dead-end hypotheses.
+
+### Checkpoint comment format
+
+```markdown
+## ⏱ Checkpoint — Experiment <attempt_id> (<model_id>)
+
+| Field | Value |
+|---|---|
+| **Attempt** | `<attempt_id>` |
+| **Hypothesis** | `<one-line description>` |
+| **Outcome** | `success` \| `failed` \| `partial` |
+| **Key finding** | `<brief insight that narrows the search space>` |
+| **Next hypothesis** | `<what to try next, or "none – surrendering">`|
+
+### Strategies tried so far
+
+| # | Hypothesis | Outcome | Finding |
+|---|---|---|---|
+| 1 | ... | failed | ... |
+| 2 | ... | failed | ... |
+
+### Environment state
+- **venv:** `venv-exp-<attempt_id>`
+- **transformers:** `<version or git commit>`
+- **openvino-tokenizers:** `<commit>`
+- **Patches generated:** `agent-results/openvino-tokenizers/patches/<name>.patch` — <what it does>
+
+<!-- checkpoint {"agent":"openvino_tokenizers_agent","attempt_id":"<attempt_id>","outcome":"<outcome>","next_hypothesis":"<text>"} -->
+```
+
+### Re-trigger resume
+
+When invoked on an issue that already has checkpoint comments, read them first and:
+1. Extract all attempted hypotheses (from the `## Strategies tried so far` tables).
+2. Skip those hypotheses in the strategy list.
+3. Start from the first untried strategy.
+4. State explicitly in your first checkpoint: `Resuming after previous session — skipping attempts 1–N`.
+
+Upload **only git patch files** (`agent-results/openvino-tokenizers/patches/*.patch` + `artifact-description.md`)
+as a GHA artifact (`tokenizers-fix-<model_type>`). No report, no log
+files, no `experiments_log.json` in the artifact.
+Include a link to the patches artifact at the end of the comment.
+
+Then **STOP**.
+
+---
+
+## Output Contract
+
+| Output field | Type | Description |
+|---|---|---|
+| `status` | `success` \| `partial` \| `failed` | Overall result |
+| `fix_applied` | `true` \| `false` | Round-trip validation passed with the fix |
+| `roundtrip_ok` | `true` \| `false` | Encode/decode round-trip validated |
+| `error_class` | string | `unknown_arch_transformers_too_old` \| `transformers_no_support` \| `tokenizer_error` |
+| `transformers_override` | string | git install URL if upgrade was needed, else empty |
+| `requires_optimum_recheck` | `true` \| `false` | Deployer/optimum must re-run with updated transformers |
+| `requires_optimum_new_arch` | `true` \| `false` | optimum-intel has no export config for this model_type |
+| `artifact_name` | string | Name of the GHA artifact: `tokenizers-fix-<model_type>` |
+| `experiments_count` | integer | Number of attempts logged |
+| `agent_report` | path | `agent_report.md` — posted to tracking issue |
+
+Generate `agent_report.md`:
+```bash
+python scripts/generate_agent_report.py \
+  --agent-name  "OpenVINO Tokenizers Agent" \
+  --model-id    "<model_id>" \
+  --status      "<status>" \
+  --error-context "<error_context>" \
+  --output      agent_report.md
+```
+
+## Constraints
+
+- Reports only to Common Orchestrator — does not call other agents directly.
+- Must validate round-trip correctness before reporting success.
+- `transformers_override` and `requires_optimum_recheck` must be set when a
+  transformers upgrade was applied — the orchestrator needs this to re-run optimum.
+- Never `--trust-remote-code`.
+- Package allowlist from `optimum_bootstrap.md` Step 3 applies here too.
+
+## Key References
+
+- openvino-tokenizers: https://github.com/openvinotoolkit/openvino_tokenizers
+- transformers source install: https://huggingface.co/docs/transformers/installation#install-from-source
+
+---
+
+## Job Communication Protocol
+
+When your work is complete — regardless of outcome — post a comment to the
+tracking issue containing **exactly** this marker on its own line:
+
+    <!-- agent-complete {"agent":"openvino_tokenizers_agent","status":"<STATUS>","fix_applied":"<true|false>","requires_optimum_new_arch":"<true|false>","next_agent":"common_orchestrator","model_id":"<MODEL_ID>","next_context":"<ONE_LINE_SUMMARY>","iteration":<N>} -->
+
+- `agent`: `"openvino_tokenizers_agent"` (fixed)
+- `status`: `"success"` | `"partial"` | `"failed"`
+- `fix_applied`: `"true"` if round-trip tokenizer validation passed, else `"false"`
+- `requires_optimum_new_arch`: `"true"` if optimum-intel still needs a new model config for this architecture
+- `next_agent`: always `"common_orchestrator"` — lets the Common Orchestrator decide
+  whether to run optimum-intel next (if `requires_optimum_new_arch=true`), re-deploy, or finalize
+- `model_id`: the sanitized HuggingFace model ID from your prompt
+- `next_context`: one-line summary (e.g. `"fix_applied, requires_optimum_new_arch=true"`)
+- `iteration`: the `iteration` value from your trigger prompt (pass it through unchanged)
+
+Place your full Markdown report above or below this marker.
+The polling job reads **only** this marker to forward outputs to the orchestrator.
+
+## Creating Pull Requests
+
+When your work is complete and all tests pass:
+
+1. Create a new branch with a descriptive name: `agent/<short-description>`
+2. Commit all changes with a clear, conventional commit message
+3. Push the branch to the fork
+4. Create a **Draft PR** to the upstream repository using `gh pr create`:
+   ```
+   gh pr create --draft \
+     --title "[Agent] <descriptive title>" \
+     --body "<description of changes, link to related PRs if any>" \
+     --repo <upstream-org>/<repo-name>
+   ```
+5. Add the label `agent-generated` if the label exists
+6. Output the PR URL for tracking
+
+Refer to the [submit-draft-pr](skills/submit-draft-pr.md) skill for detailed instructions.

--- a/.agents/skills/openvino-tokenizers/unknown-arch.md
+++ b/.agents/skills/openvino-tokenizers/unknown-arch.md
@@ -1,0 +1,382 @@
+# Skill: Handle Tokenizer Failure Caused by Unknown Model Architecture
+
+> **Scope:** This skill is **tokenizer conversion only**. It handles
+> `AutoTokenizer.from_pretrained` / `convert_tokenizer` failures caused by an
+> outdated Transformers version. It does **not** resolve the optimum-intel model
+> support gap (model configs, patchers, custom OpenVINO ops). That is the job
+> of the **Optimum-Intel agent** (skills: `optimum_debug_export` →
+> `optimum_add_model_support`).
+>
+> **When this skill is called:**
+> - Via `codingagent_tokenizers_tier1.yml` as a secondary step **after** the
+>   Optimum-Intel agent has already resolved the transformers version and
+>   model support issues. The tokenizers agent is responsible only for the
+>   tokenizer conversion half of enablement.
+> - In legacy/edge cases where the deploy pipeline routes `tokenizer_error`
+>   (pure tokenizer failures unrelated to architecture support).
+
+**Trigger (this skill is applicable when):**
+- Tokenizer conversion fails with one of these signatures:
+  - `KeyError: '<model_type>'` inside `convert_tokenizer` or tokenizer-specific code
+  - `ValueError: The checkpoint you are trying to load has model type '<model_type>'
+    but Transformers does not recognize this architecture.` — during tokenizer load
+  - `OSError: <model_id> does not appear to have a file named tokenizer*.json`
+    combined with the above
+- OR: `AutoTokenizer.from_pretrained` throws before any tokenizer-specific code runs.
+
+**Not applicable (hand off to Optimum-Intel agent):**
+- Export failures from `optimum-cli export openvino` — even if caused by old transformers
+- `model_type` not in `TasksManager` of optimum-intel (`optimum_unsupported_arch`)
+- All errors in `optimum/exporters/openvino/` traceback paths
+
+> This skill is one component of the **Autonomous Experiment Loop** defined in
+> `openvino_tokenizers.agent.md`. Always log each attempt to `experiments_log.json`
+> and follow the Surrender Protocol from that agent when you run out of hypotheses.
+
+## Context
+
+When this skill is triggered during tokenizer conversion, the model architecture
+may require a Transformers version newer than the one currently installed.
+This is NOT a tokenizer-specific bug — the standard fix is upgrading Transformers.
+
+**Important:** For `unknown_arch_transformers_too_old` routed from `classify_error.py`,
+the Optimum-Intel agent runs first and resolves the full model support (transformers
+upgrade + export pipeline). This tokenizers skill is subsequently responsible for
+confirming that the tokenizer conversion also works under the resolved environment.
+
+Known model families that have needed newer Transformers (updated as encountered):
+
+| `model_type` | Requires (approx.) | Notes |
+|---|---|---|
+| `qwen3_5` | `transformers>=4.57.0.dev0` | Hybrid DeltaNet + GQA, multimodal |
+| _(add new entries here as discovered)_ | | |
+
+## Steps
+
+### 0. Consume Cross-Agent Artifacts (run FIRST when called after Optimum-Intel agent)
+
+When invoked after the Optimum-Intel agent, a `transformers_override` may
+already be recorded in the shared manifest artifact. Apply it **before** any
+other step — do not re-discover what the previous agent already solved.
+
+```bash
+# Bootstrap from the shared manifest (picks up transformers_override, patches, etc.)
+if [ -f meat_manifest.json ]; then
+  python scripts/collect_artifacts.py bootstrap --manifest meat_manifest.json | bash
+fi
+
+# Also check the direct tokenizer artifact if present
+if [ -f tokenizers-artifact/artifact-description.md ]; then
+  cat tokenizers-artifact/artifact-description.md
+fi
+
+# Verify what transformers version is now active
+python -c "import transformers; print(transformers.__version__)"
+```
+
+If the manifest already contains a working `transformers_install` URL, use it:
+```bash
+# From manifest: transformers_install = "git+https://github.com/huggingface/transformers@main"
+# or a specific version like "transformers==4.57.0"
+pip install --quiet "$transformers_install"
+```
+
+Proceed directly to **Step 3a (tokenizer conversion)** if the transformers
+version is already resolved by the manifest. Skip Steps 1–3.
+
+Log this as `attempt_id: exp-000-consume-artifacts` in `experiments_log.json`.
+
+### 1. Upstream Pattern Search (run when this skill is primary responder)
+
+Search for existing fixes in public repos before writing new code:
+
+```bash
+MODEL_TYPE="<model_type>"
+
+# openvino_tokenizers PRs/issues
+curl -sf -H "Authorization: Bearer $GITHUB_TOKEN" \
+  "https://api.github.com/search/issues?q=${MODEL_TYPE}+repo:openvinotoolkit/openvino_tokenizers&per_page=5" \
+  | python -c "import json,sys;[print(i['number'],i['state'],i['title'],i['html_url']) for i in json.load(sys.stdin).get('items',[])]"
+
+# transformers changelog / PRs for this model_type
+curl -sf -H "Authorization: Bearer $GITHUB_TOKEN" \
+  "https://api.github.com/search/issues?q=${MODEL_TYPE}+repo:huggingface/transformers+label:New+model&per_page=5" \
+  | python -c "import json,sys;[print(i['number'],i['state'],i['title'],i['html_url']) for i in json.load(sys.stdin).get('items',[])]"
+
+# Local git history in the ref clone
+cd "${TOKENIZERS_DIR:-/tmp/openvino-tokenizers-ref}"
+git log --oneline --all --grep="$MODEL_TYPE" | head -20
+```
+
+If a relevant merged PR exists in `openvino_tokenizers` → fetch and apply it
+to the experimental source clone before attempting anything else:  it may be
+a direct fix.
+
+Log this as `attempt_id: exp-000-upstream-search` in `experiments_log.json`.
+
+### 1. Identify the failing `model_type`
+
+Extract from the error traceback:
+```python
+import re, pathlib
+
+log_text = pathlib.Path("error.log").read_text()
+m = re.search(r"model type `(\w+)`", log_text) or \
+    re.search(r"KeyError: '(\w+)'", log_text)
+model_type = m.group(1) if m else None
+print(f"Unknown model_type: {model_type}")
+```
+
+If `model_type` is found → continue.
+If not → this is a different tokenizer error; escalate to the orchestrator
+with `error_class=tokenizer_error`.
+
+### 2. Check Latest Stable PyPI Release First
+
+Before reaching for git-HEAD, verify whether the latest *released* transformers
+version already contains the fix — this is a lighter-weight upgrade.
+
+```bash
+# Get latest released version from PyPI
+LATEST=$(pip index versions transformers 2>/dev/null \
+  | grep -oP '(?<=Available versions: )[\.\d]+' | head -1)
+INSTALLED=$(pip show transformers | grep '^Version' | awk '{print $2}')
+echo "Installed: $INSTALLED  |  Latest PyPI: $LATEST"
+```
+
+If `$INSTALLED != $LATEST`, upgrade and re-probe:
+
+```bash
+pip install --quiet "transformers==$LATEST"
+python - <<'EOF'
+from transformers import AutoConfig
+try:
+    cfg = AutoConfig.from_pretrained("$MODEL_ID", trust_remote_code=False)
+    print(f"PyPI latest OK: {cfg.model_type}")
+except Exception as e:
+    print(f"Still failing after PyPI upgrade: {e}")
+EOF
+```
+
+If the probe passes → retry tokenizer conversion (Step 3a), record
+`transformers_install: "transformers==$LATEST"` in `transformers_dep.json`.
+
+### 3. If Latest PyPI Still Fails — Try git-HEAD
+
+```bash
+# Install transformers from git (do NOT upgrade other packages)
+pip install --quiet \
+  "git+https://github.com/huggingface/transformers@main" \
+  --no-deps           # avoid accidentally dragging incompatible versions
+```
+
+Then probe:
+```python
+from transformers import AutoConfig
+try:
+    cfg = AutoConfig.from_pretrained("$MODEL_ID", trust_remote_code=False)
+    print(f"Config loaded OK: {cfg.model_type}")
+    supported = True
+except Exception as e:
+    print(f"Still failing: {e}")
+    supported = False
+```
+
+> **Important:** If `--no-deps` causes an `ImportError` in transformers itself,
+> retry without `--no-deps`:
+> ```bash
+> pip install --quiet "git+https://github.com/huggingface/transformers@main"
+> ```
+
+### 4a. If git Transformers works → retry tokenizer conversion
+
+```bash
+optimum-cli export openvino \
+  --model "$MODEL_ID" \
+  --task text-generation-with-past \
+  --weight-format int4 \
+  "$OUTPUT_DIR"
+```
+
+Check whether `openvino_tokenizer.xml` / `openvino_detokenizer.xml` were created.
+
+Validate round-trip:
+```python
+from openvino_tokenizers import convert_tokenizer
+from transformers import AutoTokenizer
+from openvino import Core
+
+tokenizer = AutoTokenizer.from_pretrained("$MODEL_ID")
+ov_tokenizer, ov_detokenizer = convert_tokenizer(tokenizer, with_detokenizer=True)
+
+ie = Core()
+compiled_tok = ie.compile_model(ov_tokenizer)
+compiled_detok = ie.compile_model(ov_detokenizer)
+
+test_texts = ["Hello, world!", "Привет, мир!", "你好世界"]
+for text in test_texts:
+    ids = tokenizer(text, return_tensors="np").input_ids
+    ov_ids = compiled_tok({"string_input": [text]})["input_ids"]
+    assert (ids == ov_ids).all(), f"Token ID mismatch for: {text}"
+
+print("Round-trip OK")
+```
+
+If round-trip passes → proceed to Step 4.
+If round-trip fails → record as `tokenizer_error` and escalate with details.
+
+### 4b. If git Transformers still fails — Patch the Source
+
+`--trust-remote-code` is **never** an acceptable mitigation — treat any
+requirement for it as an immediate Surrender trigger.
+
+If git-HEAD transformers still does not recognise the `model_type`, the feature
+has **not been merged upstream yet** — but this does not mean we must surrender.
+
+Invoke the **`optimum_patch_transformers`** skill
+(`skills/optimum-intel/patch-transformers.md`) which will:
+
+1. Search transformers GitHub for an open/merged PR for this `model_type`.
+2. If found → cherry-pick the PR onto a local transformers clone.
+3. If not found → extract the config class from the HF model repo and register
+   it in the local transformers clone.
+4. Install from the patched local clone and test.
+5. On success → generate a `git format-patch` via `scripts/generate_git_patch.py`.
+6. Post the patch to the GitHub issue as a comment and attach it to the
+   cross-agent artifact.
+7. Signal `transformers_source_patched=true` to the orchestrator.
+
+Only trigger the **Surrender Protocol** from `openvino_tokenizers.agent.md`
+if the `optimum_patch_transformers` skill itself exhausts all strategies
+(no config file in model repo, PR cherry-pick conflicts unresolvable, etc.).
+
+### 5. Create a dependency patch
+
+If Step 4a succeeded (git transformers worked + round-trip passed), record
+the dependency and produce the cross-agent artifact:
+
+Write `agent-results/openvino-tokenizers/patches/transformers_dep.json`:
+```json
+{
+  "model_type": "<model_type>",
+  "transformers_install": "git+https://github.com/huggingface/transformers@main",
+  "transformers_version_used": "<x.y.z.devN from: pip freeze | grep transformers>",
+  "reason": "not_in_stable_release"
+}
+```
+
+If changes to `openvino_tokenizers` source were also needed (beyond the
+transformers upgrade), generate a `git format-patch` from the experimental
+source clone:
+```bash
+cd "${TOKENIZERS_SRC:-/tmp/openvino-tokenizers-src}"
+git add -A
+git commit -m "fix(<model_type>): add tokenizer conversion support"
+git format-patch HEAD~1 -o agent-results/openvino-tokenizers/patches/ \
+  --stdout > agent-results/openvino-tokenizers/patches/<attempt_id>-<model_type>-tokenizer.patch
+```
+
+Then log this attempt and assemble the cross-agent artifact per the
+protocol in `openvino_tokenizers.agent.md` (Cross-Agent Artifact Protocol).
+
+### 6. Signal back to Optimum-Intel agent
+
+**Critical:** If `agent-results/openvino-tokenizers/patches/transformers_dep.json` was created, the
+orchestrator MUST re-run the **Optimum-Intel agent** (or at minimum the
+deployer) with `transformers_override` set to the git URL.
+
+Write to the job output:
+```bash
+echo "transformers_override=git+https://github.com/huggingface/transformers@main" >> "$GITHUB_OUTPUT"
+echo "requires_optimum_recheck=true" >> "$GITHUB_OUTPUT"
+echo "model_type=<model_type>" >> "$GITHUB_OUTPUT"
+```
+
+This allows the orchestrator to trigger a Pass-2 deploy with the updated
+dependency before declaring success.
+
+### 6. Check optimum-intel compatibility
+
+After upgrading Transformers, verify that the installed `optimum-intel` is
+compatible:
+
+```python
+from optimum.exporters.tasks import TasksManager
+try:
+    tasks = TasksManager.get_supported_tasks_for_model_type(
+        "<model_type>", exporter="openvino"
+    )
+    print(f"optimum-intel supports: {tasks}")
+    optimum_ok = True
+except KeyError:
+    print("model_type not in optimum-intel → Optimum-Intel agent still needed")
+    optimum_ok = False
+```
+
+If `optimum_ok=False`:
+- Set `requires_optimum_new_arch=true` in the output.
+- The orchestrator should invoke the **Optimum-Intel agent** with skill
+  `optimum_add_model_support` even if tokenizer conversion itself succeeded.
+
+## Decision Tree Summary
+
+```
+Tokenizer fails with "does not recognize this architecture"
+  │
+  ├─ Step 0: upstream_search → known fix found? → apply and test first
+  │
+  ├─ Install transformers from git (allowed origin: github.com/huggingface/)
+  │     │
+  │     ├─ Config loads OK
+  │     │     │
+  │     │     ├─ Round-trip OK → create dep patch → assemble cross-agent artifact
+  │     │     │
+  │     │     └─ Round-trip FAIL → error_class=tokenizer_error, iterate hypothesis
+  │     │
+  │     └─ Still fails → status=blocked, error_class=transformers_no_support
+  │                       → Surrender Protocol
+  │
+  └─ Check optimum-intel TasksManager
+        ├─ Supported → tokenizer fix alone sufficient
+        └─ Not supported → flag requires_optimum_new_arch=true
+```
+
+> `--trust-remote-code` is not a branch in this tree. It is always a blocker.
+
+## Experiment Journal
+
+After each meaningful step (upstream search, each install attempt, each
+round-trip test), append an entry to `experiments_log.json`.
+Minimum fields: `attempt_id`, `hypothesis`, `outcome`, `error_summary`,
+`insights`, `next_hypothesis`.
+
+## Output Contract (additions to base agent)
+
+| Field | Value |
+|---|---|
+| `error_class` | `unknown_arch_transformers_too_old` \| `transformers_no_support` \| `tokenizer_error` |
+| `transformers_override` | git URL if upgrade was needed, else empty |
+| `requires_optimum_recheck` | `true` if deploy must be re-run with new transformers |
+| `requires_optimum_new_arch` | `true` if optimum-intel has no config for this model_type |
+
+## Surrender Checklist
+
+Before triggering the Surrender Protocol, verify all boxes are ticked:
+
+- [ ] Upstream search completed (Step 0) and results documented
+- [ ] `model_type` correctly identified from traceback
+- [ ] git-HEAD transformers installed and tested in an isolated venv
+- [ ] Round-trip test attempted (if transformers loaded OK)
+- [ ] `experiments_log.json` has an entry for every attempt
+- [ ] Root cause is clearly one of: `transformers_no_support`, `tokenizer_error`, security blocker
+- [ ] Human handoff sections in `agent_report.md` are specific and actionable
+
+## Notes
+
+- Never use `--trust-remote-code` — its requirement is an immediate Surrender trigger.
+- Never hard-pin a `transformers` git SHA in `requirements.txt` of this repo —
+  patch files are for the CI pipeline environment only.
+- Document the exact `transformers.__version__` in `transformers_dep.json` for reproducibility.
+- When upgrading transformers, also verify the Rust `tokenizers` library
+  version compatibility — new vocab sizes (e.g., 248320 for Qwen3.5) sometimes
+  require an updated `tokenizers` package (check allowlist before installing).

--- a/.agents/skills/submit-draft-pr.md
+++ b/.agents/skills/submit-draft-pr.md
@@ -1,0 +1,107 @@
+---
+name: submit-draft-pr
+description: Optionally create a draft PR to the upstream repo from a local source directory. Used by coding agents when a local source path is available in the context file.
+---
+
+# Skill: Submit Draft PR
+
+> **Optional.** Attempt this only when all of the following are true:
+> - Your context file provides a local source path (e.g. `OpenVINO source code: /path/to/openvino`)
+> - That path is accessible and is a git repository
+> - `gh` CLI is available and authenticated (`gh auth status`)
+>
+> If any condition is not met — **skip silently** and log one line. Do not fail.
+
+---
+
+## When to invoke
+
+After completing your main implementation work and writing results to
+`agent-results/<agent>/`, call this skill to open a **draft PR** from your
+changes to the upstream repo.
+
+This is *in addition to* — never instead of — generating patch files and
+writing results to `agent-results/`.
+
+---
+
+## Steps
+
+### 1. Verify prerequisites
+
+```bash
+# Is gh available and authenticated?
+gh auth status || { echo "[draft-pr] gh not available — skipping"; exit 0; }
+
+# Is the source path a git repo?
+[ -d "${SOURCE_PATH}/.git" ] || { echo "[draft-pr] ${SOURCE_PATH} is not a git repo — skipping"; exit 0; }
+```
+
+### 2. Choose a branch name
+
+Use a descriptive kebab-case branch name derived from the work done:
+
+```
+fix/add-<op-name>-op              # core op or FE op
+fix/add-<pass-name>-transformation
+fix/<model-id>-export             # optimum-intel / tokenizers
+fix/<component>-<short-desc>      # general
+```
+
+### 3. Run the helper script
+
+```bash
+python scripts/create_draft_pr.py \
+  --repo-dir "${SOURCE_PATH}" \
+  --branch   "<branch-name>" \
+  --title    "<one-line description of the fix>" \
+  --body-file agent-results/<agent>/agent_report.md \
+  [--upstream <org/repo>]          # only if auto-detection might fail
+```
+
+The script will:
+1. Detect whether `origin` is a fork or the upstream directly
+2. Ensure a personal fork exists (creates one via `gh repo fork` if needed)
+3. Create the feature branch (or reuse an existing one with the same name)
+4. `git add -A && git commit` any staged/unstaged changes
+5. Push to the fork (`git remote add fork <fork-url>`)
+6. Open a **draft PR** to the upstream repo via `gh pr create --draft`
+7. Print the PR URL on success
+
+### 4. Log the result
+
+After the script runs, record the outcome in `agent-results/<agent>/session.md`:
+
+```
+[draft-pr] PR opened: <pr_url>
+```
+
+or
+
+```
+[draft-pr] Skipped: <reason>
+```
+
+---
+
+## Per-repo upstream table
+
+| Agent | Upstream repo |
+|---|---|
+| transformation, core-opspec, pytorch-fe, cpu, gpu, npu | `openvinotoolkit/openvino` |
+| optimum-intel | `huggingface/optimum-intel` |
+| openvino-tokenizers | `openvinotoolkit/openvino_tokenizers` |
+| openvino-genai | `openvinotoolkit/openvino.genai` |
+
+Pass `--upstream <value>` only when auto-detection from the git remote is likely
+to fail (e.g. the local clone uses an internal mirror URL).
+
+---
+
+## Important constraints
+
+- Always create PRs as **drafts** — never ready-for-review.
+- PR target is the **upstream** repo, not the fork.
+- Do not push to `main`/`master` of any repo.
+- If `git push --force-with-lease` fails (e.g. diverged history), skip and log — do not `--force`.
+- Do not block the agent's completion on PR success — log the failure and continue.


### PR DESCRIPTION
## Summary

This PR migrates Copilot agent and skill instruction files from the central MEAT repository into this repo's new \.agents/\ directory structure.

### What's included
- Agent definitions in \.agents/*.agent.md\`n- Skill instructions in \.agents/skills/*/\`n
### Migration source
Original files from internal sandbox
---
_This PR was generated by an automated migration agent._