### PR TITLE
Fix tokenizer extension symbol conflicts on Linux

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -383,6 +383,11 @@ ov_tokenizers_link_pcre2(${TARGET_NAME})
 string(REPLACE " " ";" extra_flags "${c_cxx_flags} ${cxx_flags}")
 set_target_properties(${TARGET_NAME} PROPERTIES COMPILE_OPTIONS "${extra_flags}")
 
+# On Linux, set linker options to hide symbols and avoid conflicts with OpenVINO's symbols
+if(LINUX)
+  target_link_options(${TARGET_NAME} PRIVATE "-Wl,--exclude-libs,ALL")
+endif()
+
 target_compile_definitions(${TARGET_NAME} PRIVATE IMPLEMENT_OPENVINO_EXTENSION_API)
 target_link_libraries(${TARGET_NAME} PRIVATE openvino::runtime openvino::threading)
 


### PR DESCRIPTION
## Summary

Fix a Linux crash in `CharsMapNormalization` with `Lightricks/LTX-Video` by hiding symbols from statically linked dependencies in the tokenizer extension.

The extension links SentencePiece statically, which also brings in protobuf-lite symbols. Without hiding those symbols, they can be exported from `libopenvino_tokenizers.so` and conflict with other protobuf symbols loaded in the same process. This can corrupt protobuf global state and lead to crashes during `NormalizerSpec` initialization.

## Changes

- Add `-Wl,--exclude-libs,ALL` for Linux builds of `libopenvino_tokenizers.so`.
- Keep bundled SentencePiece/protobuf-lite symbols private to the tokenizer extension.

## Ticket 
CVS-185349
