### PR TITLE
[EXPERIMENT][WIP] fix(metaspace): correct pipeline order for prepend_scheme=first with split=True

### DIFF
--- a/python/openvino_tokenizers/hf_parser.py
+++ b/python/openvino_tokenizers/hf_parser.py
@@ -247,7 +247,15 @@ class TransformersTokenizerPipelineParser:
         try:
             steps = self.pre_tokenization_map[step_dict["type"]](step_dict)
             if step_dict["type"] == "Metaspace" and step_dict.get("prepend_scheme", "never") == "first":
-                first_prepend = steps.pop()
+                # The "first prepend" step is always a NormalizationStep (RegexNormalizationStep).
+                # When split=True, parse_metaspace appends a RegexSplitStep as the last step,
+                # so we must find the last NormalizationStep rather than blindly popping the tail.
+                # Fixes seamless_m4t_v2 / any BPE tokenizer using Metaspace with split=True.
+                prepend_idx = next(
+                    i for i in range(len(steps) - 1, -1, -1)
+                    if isinstance(steps[i], NormalizationStep)
+                )
+                first_prepend = steps.pop(prepend_idx)
                 self.pipeline.steps.insert(0, first_prepend)
             self.pipeline.add_steps(steps)
         except KeyError as error:

--- a/python/openvino_tokenizers/tokenizer_pipeline.py
+++ b/python/openvino_tokenizers/tokenizer_pipeline.py
@@ -1583,21 +1583,41 @@ class TokenizerPipeline:
 
             if self.is_metaspace_prepend_first:
                 prepend_metaspace_step = self.steps.pop(0)
+
+                # Apply normalization steps on the flat (non-ragged) string BEFORE the prepend.
+                # This is necessary when the normalizer maps ▁ back to a space (e.g. the
+                # Precompiled charsmap used by SeamlessM4T / NLLB tokenizers): if the prepend
+                # runs first it inserts ▁, the charsmap then converts it back to a space, and
+                # the word loses its metaspace prefix.  Running normalizers first avoids this.
+                for step in self.normalization_steps:
+                    input_node = step.get_ov_subgraph(input_node)
+
                 input_node = prepend_metaspace_step.get_ov_subgraph(input_node)
 
-            ragged = []
-            if isinstance(self.steps[0], SpecialTokensSplit):
-                input_node = self.add_ragged_dimension(input_node)
-                input_node = self.steps[0].get_ov_subgraph(input_node)
-                ragged, input_node = input_node[:2], input_node[2:]
+                ragged = []
+                if isinstance(self.steps[0], SpecialTokensSplit):
+                    input_node = self.add_ragged_dimension(input_node)
+                    input_node = self.steps[0].get_ov_subgraph(input_node)
+                    ragged, input_node = input_node[:2], input_node[2:]
 
-            for step in self.normalization_steps:
-                input_node = step.get_ov_subgraph(input_node)
-
-            if not ragged:
-                input_node = self.add_ragged_dimension(input_node)
+                if not ragged:
+                    input_node = self.add_ragged_dimension(input_node)
+                else:
+                    input_node = ragged + input_node
             else:
-                input_node = ragged + input_node
+                ragged = []
+                if isinstance(self.steps[0], SpecialTokensSplit):
+                    input_node = self.add_ragged_dimension(input_node)
+                    input_node = self.steps[0].get_ov_subgraph(input_node)
+                    ragged, input_node = input_node[:2], input_node[2:]
+
+                for step in self.normalization_steps:
+                    input_node = step.get_ov_subgraph(input_node)
+
+                if not ragged:
+                    input_node = self.add_ragged_dimension(input_node)
+                else:
+                    input_node = ragged + input_node
 
             for step in self.pre_tokenization_steps:
                 input_node = step.get_ov_subgraph(input_node)

--- a/tests/tokenizers_test.py
+++ b/tests/tokenizers_test.py
@@ -104,6 +104,7 @@ bpe_models = [
     "answerdotai/ModernBERT-base",
     "tiiuae/Falcon3-7B-Instruct",
     "LiquidAI/LFM2-350M",
+    "facebook/seamless-m4t-v2-large",  # Metaspace BPE, prepend_scheme=first, split=True
 ]
 sentencepiece_models = [
     # bpe


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY MEAT AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created by an AI agent as part of automated model enablement.
> A human maintainer must review and approve it before it can be considered for merge.
> Do **NOT** merge without human review and sign-off.

## Description

Two bugs prevented correct conversion of tokenizers that use a Metaspace pre-tokenizer with **`prepend_scheme="first"` AND `split=True`** — specifically `SeamlessM4TTokenizerFast` (used by `facebook/seamless-m4t-v2-large`, `facebook/nllb-200-distilled-600M`, etc.).

### Bug 1 — `hf_parser.py`: wrong step inserted at pipeline position 0

**Symptom:** C++ `BPETokenizer` raised `Incorrect number of inputs` (received 17, expected 18).

**Root cause:** In `parse_pre_tokenization_step`, `parse_metaspace` returns `[RN_replace_spaces, RN_prepend_first, RegexSplitStep]` for the `split=True + prepend_scheme=first` case. The previous code called `steps.pop()`, which popped the **last** element (`RegexSplitStep` instead of `RN_prepend_first`) and inserted it at pipeline position 0. This displaced `SpecialTokensSplit` from position 0, so it was never processed, and the skip tensor was never produced — causing the BPE op to receive the wrong number of inputs.

**Fix:** Use `next(i for ... if isinstance(steps[i], NormalizationStep))` to find the last `NormalizationStep` (i.e., `RN_prepend_first`) instead of blindly popping the tail.

### Bug 2 — `tokenizer_pipeline.py`: Charsmap normalizer destroys the prepended ▁

**Symptom:** Token IDs were wrong — the first word was tokenized without its metaspace prefix (e.g. `"Hello"` instead of `"▁Hello"`), producing 3 tokens instead of 2 for `"Hello world"`.

**Root cause:** In `get_tokenizer_ov_subgraph`, the `is_metaspace_prepend_first` branch ran the prepend step **before** normalization. The `Precompiled` charsmap in `SeamlessM4T`'s normalizer maps U+2581 (▁) back to a regular space — so it silently undid the prepend.

**Fix:** In the `is_metaspace_prepend_first` branch, run all `normalization_steps` on the flat string **before** the prepend step. The non-prepend path is unchanged.

## Correct execution order (after fix)

```
StringTensorUnpack
  → normalization_steps (Charsmap, Strip, Replace) on flat string
  → RN_prepend_first (adds ▁ to first non-space char)
  → add_ragged_dimension / SpecialTokensSplit
  → pre_tokenization_steps (RN_replace_spaces, RegexSplit)
  → BPETokenizationStep
```

## Test results

| Model | Token IDs | Detokenizer |
|-------|-----------|-------------|
| `facebook/seamless-m4t-v2-large` | ✅ All match HuggingFace | ✅ Pass |
| `openai-community/gpt2` (regression) | ✅ Pass | ✅ Pass |
| `google-bert/bert-base-uncased` (regression) | ✅ Pass | ✅ Pass |

## Files changed

- `python/openvino_tokenizers/hf_parser.py` — Fix 1: correct step selection for metaspace+split
- `python/openvino_tokenizers/tokenizer_pipeline.py` — Fix 2: run normalizers before prepend
- `tests/tokenizers_test.py` — add `facebook/seamless-m4t-v2-large` to `bpe_models` test list

Fixes: `SeamlessM4TTokenizerFast`, `NllbTokenizerFast` and any model using HF fast tokenizer with Metaspace `prepend_scheme=first` + `split=True`.