### PR TITLE
Add ai.onnx.contrib string-op ONNX conversion extensions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -529,6 +529,7 @@ jobs:
       matrix:
         build_type: [Release] # TODO: Add Debug build when OV provider is ready or use OV package
     needs: [openvino_download, openvino_tokenizers_wheel, openvino_tokenizers_cpack]
+    timeout-minutes: 10
     defaults:
       run:
         shell: bash

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -458,13 +458,77 @@ jobs:
           if-no-files-found: 'warn'
 
 
+  openvino_onnx_contrib_tests:
+    name: OpenVINO ONNX contrib tests
+    needs: [ openvino_download, openvino_tokenizers_wheel]
+    if: always() && needs.openvino_tokenizers_wheel.result == 'success'
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+    runs-on: ubuntu-22.04
+    env:
+      INSTALL_DIR: ${{ github.workspace }}/openvino/install
+
+    steps:
+      - name: Clone Openvino tokenizers sources and tests
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+
+      - name: Download tokenizers package
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: openvino_tokenizers_wheel
+          path: ${{ env.INSTALL_DIR }}/ov_tokenizers
+
+      - name: Download OpenVINO package
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: ${{ needs.openvino_download.outputs.ov_artifact_name }}
+          path: ${{ env.INSTALL_DIR }}
+          merge-multiple: true
+
+      - name: Configure poetry
+        uses: ./.github/actions/install_poetry
+
+      - name: Find OpenVINO wheel
+        uses: ./.github/actions/find_wheel
+        id: ov_wheel
+        with:
+          wheels_dir: '${{ env.INSTALL_DIR }}/wheels'
+          package_name: 'openvino'
+
+      - name: Install OpenVINO wheel
+        run: poetry add ${{ steps.ov_wheel.outputs.wheel_path }}
+
+      - name: Find Tokenizers wheel
+        uses: ./.github/actions/find_wheel
+        id: tokenizers_wheel
+        with:
+          wheels_dir: '${{ env.INSTALL_DIR }}/ov_tokenizers'
+          package_name: 'openvino_tokenizers'
+
+      - name: Install OpenVINO tokenizers wheel
+        run: poetry run pip install --no-deps ${{ steps.tokenizers_wheel.outputs.wheel_path }}
+
+      - name: Install Test dependencies
+        run: poetry install --with dev,onnx_tests
+
+      - name: ONNX contrib extension tests
+        run: poetry run pytest tests/onnx_contrib_test.py
+
+
   store_artifacts:
     name: Store build artifacts
     strategy:
       matrix:
         build_type: [Release] # TODO: Add Debug build when OV provider is ready or use OV package
     needs: [openvino_download, openvino_tokenizers_wheel, openvino_tokenizers_cpack]
-    timeout-minutes: 10
     defaults:
       run:
         shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -439,6 +439,72 @@ jobs:
           . "${{ env.INSTALL_DIR }}/setupvars.ps1"
           poetry run pytest tests
 
+  openvino_onnx_contrib_tests:
+    name: OpenVINO ONNX contrib tests
+    needs: [ openvino_download, openvino_tokenizers_wheel]
+    if: always() && needs.openvino_tokenizers_wheel.result == 'success'
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: pwsh
+    runs-on: windows-latest
+    env:
+      INSTALL_DIR: ${{ github.workspace }}\\openvino\\install
+
+    steps:
+      - name: Clone Openvino tokenizers sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+
+      - name: Download tokenizers package
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: openvino_tokenizers_wheel
+          path: ${{ env.INSTALL_DIR }}\\ov_tokenizers
+
+      - name: Download OpenVINO package
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: ${{ needs.openvino_download.outputs.ov_artifact_name }}
+          path: ${{ env.INSTALL_DIR }}
+          merge-multiple: true
+
+      - name: Configure poetry
+        uses: ./.github/actions/install_poetry
+
+      - name: Find OpenVINO wheel
+        uses: ./.github/actions/find_wheel
+        id: ov_wheel
+        with:
+          wheels_dir: '${{ env.INSTALL_DIR }}\\wheels'
+          package_name: 'openvino'
+
+      - name: Install OpenVINO wheel
+        run: poetry add ${{ steps.ov_wheel.outputs.wheel_path }}
+
+      - name: Find Tokenizers wheel
+        uses: ./.github/actions/find_wheel
+        id: tokenizers_wheel
+        with:
+          wheels_dir: '${{ env.INSTALL_DIR }}\\ov_tokenizers'
+          package_name: 'openvino_tokenizers'
+
+      - name: Install OpenVINO tokenizers wheel
+        run: poetry run pip install --no-deps ${{ steps.tokenizers_wheel.outputs.wheel_path }}
+
+      - name: Install Test dependencies
+        run: poetry install --with dev,onnx_tests
+
+      - name: ONNX contrib extension tests
+        run: |
+          . "${{ env.INSTALL_DIR }}/setupvars.ps1"
+          poetry run pytest tests/onnx_contrib_test.py
+
   store_artifacts:
     name: Store build artifacts
     strategy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,13 +121,18 @@ optional = true
 
 [tool.poetry.group.dev.dependencies]
 ruff = ">=0.1.0,<=0.12.8"
-onnx = ">=1.13.0"
 bandit = ">=1.7.0,<=1.8.6"
 pytest = ">=7.0.0,<=8.3.5"
 pytest-xdist = ">=3.4.0,<=3.8.0"
 pytest-harvest = ">=1.6.0,<=1.10.0"
 pandas = ">=2.0.0,<=2.3.1"
 jinja2 = ">=3.0.0,<=3.1.6"
+
+[tool.poetry.group.onnx_tests]
+optional = true
+
+[tool.poetry.group.onnx_tests.dependencies]
+onnx = ">=1.13.0"
 
 [tool.poetry.group.benchmark]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ optional = true
 
 [tool.poetry.group.onnx_tests.dependencies]
 onnx = ">=1.13.0"
+sentencepiece = ">=0.1.96"
 
 [tool.poetry.group.benchmark]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ optional = true
 
 [tool.poetry.group.dev.dependencies]
 ruff = ">=0.1.0,<=0.12.8"
+onnx = ">=1.13.0"
 bandit = ">=1.7.0,<=1.8.6"
 pytest = ">=7.0.0,<=8.3.5"
 pytest-xdist = ">=3.4.0,<=3.8.0"

--- a/src/contrib_string_ops.cpp
+++ b/src/contrib_string_ops.cpp
@@ -23,6 +23,7 @@ std::string read_scalar_packed_string(const ov::Tensor& begins_t,
     auto begins = begins_t.data<const int32_t>();
     auto ends   = ends_t.data<const int32_t>();
     auto chars  = chars_t.data<const uint8_t>();
+    OPENVINO_ASSERT(ends[0] >= begins[0], "Malformed packed string: ends[0] < begins[0]");
     return std::string(reinterpret_cast<const char*>(chars + begins[0]),
                        static_cast<size_t>(ends[0] - begins[0]));
 }
@@ -88,15 +89,18 @@ bool ContribStringJoin::evaluate(ov::TensorVector& outputs,
             OPENVINO_THROW("ContribStringJoin: unsupported axis element type ", at);
     }
 
+    if (in_rank > 0) {
+        if (axis < 0)
+            axis += static_cast<int64_t>(in_rank);
+        OPENVINO_ASSERT(axis >= 0 && static_cast<size_t>(axis) < in_rank,
+                        "ContribStringJoin axis out of range");
+    }
+
     // Handle 0-D / single-string degenerate case: identity copy.
     if (in_rank == 0 || ov::shape_size(in_shape) <= 1) {
         ov::Shape out_shape = (in_rank <= 1) ? ov::Shape{} : in_shape;
         if (in_rank > 1) {
-            int64_t axis_norm = axis;
-            if (axis_norm < 0) axis_norm += static_cast<int64_t>(in_rank);
-            OPENVINO_ASSERT(axis_norm >= 0 && static_cast<size_t>(axis_norm) < in_rank,
-                            "ContribStringJoin axis out of range");
-            out_shape.erase(out_shape.begin() + static_cast<size_t>(axis_norm));
+            out_shape.erase(out_shape.begin() + axis);
         }
         outputs[0].set_shape(out_shape);
         outputs[1].set_shape(out_shape);
@@ -114,12 +118,6 @@ bool ContribStringJoin::evaluate(ov::TensorVector& outputs,
         }
         return true;
     }
-
-    if (axis < 0) {
-        axis += static_cast<int64_t>(in_rank);
-    }
-    OPENVINO_ASSERT(axis >= 0 && static_cast<size_t>(axis) < in_rank,
-                    "ContribStringJoin axis out of range");
 
     // Compute strides for input (row-major).
     std::vector<size_t> in_strides(in_rank, 1);
@@ -146,9 +144,9 @@ bool ContribStringJoin::evaluate(ov::TensorVector& outputs,
 
     std::vector<std::string> result(out_size);
     size_t total_chars = 0;
+    std::vector<size_t> coords_out(out_shape.size());
     for (size_t oi = 0; oi < out_size; ++oi) {
         // Unravel oi in out_shape order.
-        std::vector<size_t> coords_out(out_shape.size());
         size_t r = oi;
         for (size_t d = 0; d < out_shape.size(); ++d) {
             coords_out[d] = r / out_strides[d];
@@ -248,11 +246,12 @@ bool ContribStringSplit::evaluate(ov::TensorVector& outputs,
     std::vector<std::string> values;
     size_t max_tokens = 0;
 
+    std::vector<int64_t> coord(in_rank);
     for (size_t p = 0; p < in_size; ++p) {
+        OPENVINO_ASSERT(ends[p] >= begins[p], "Malformed packed string: ends[", p, "] < begins[", p, "]");
         std::string_view s(reinterpret_cast<const char*>(chars + begins[p]),
                            static_cast<size_t>(ends[p] - begins[p]));
 
-        std::vector<int64_t> coord(in_rank);
         size_t r = p;
         for (size_t d = 0; d < in_rank; ++d) {
             coord[d] = static_cast<int64_t>(r / in_strides[d]);
@@ -280,12 +279,15 @@ bool ContribStringSplit::evaluate(ov::TensorVector& outputs,
             }
         }
 
+        // tok_pos tracks the original slot position in the split sequence so
+        // that sparse COO indices correctly reflect pre-skip positions.
         size_t tok_pos = 0;
         for (auto& t : tokens) {
-            if (skip_empty && t.empty()) continue;
-            indices_flat.insert(indices_flat.end(), coord.begin(), coord.end());
-            indices_flat.push_back(static_cast<int64_t>(tok_pos));
-            values.emplace_back(t);
+            if (!skip_empty || !t.empty()) {
+                indices_flat.insert(indices_flat.end(), coord.begin(), coord.end());
+                indices_flat.push_back(static_cast<int64_t>(tok_pos));
+                values.emplace_back(t);
+            }
             ++tok_pos;
         }
         if (tok_pos > max_tokens) max_tokens = tok_pos;

--- a/src/contrib_string_ops.cpp
+++ b/src/contrib_string_ops.cpp
@@ -18,8 +18,8 @@ namespace {
 std::string read_scalar_packed_string(const ov::Tensor& begins_t,
                                       const ov::Tensor& ends_t,
                                       const ov::Tensor& chars_t) {
-    OPENVINO_ASSERT(begins_t.get_size() >= 1,
-                    "Expected at least one element in packed string scalar");
+    OPENVINO_ASSERT(begins_t.get_size() == 1 && ends_t.get_size() == 1,
+                    "Expected a scalar packed string (single begins/ends element)");
     auto begins = begins_t.data<const int32_t>();
     auto ends   = ends_t.data<const int32_t>();
     auto chars  = chars_t.data<const uint8_t>();
@@ -77,6 +77,8 @@ bool ContribStringJoin::evaluate(ov::TensorVector& outputs,
 
     int64_t axis;
     {
+        OPENVINO_ASSERT(inputs[6].get_size() == 1,
+                        "ContribStringJoin axis input must be a scalar (single element)");
         const auto& at = inputs[6].get_element_type();
         if (at == element::i64)
             axis = inputs[6].data<const int64_t>()[0];
@@ -90,7 +92,11 @@ bool ContribStringJoin::evaluate(ov::TensorVector& outputs,
     if (in_rank == 0 || ov::shape_size(in_shape) <= 1) {
         ov::Shape out_shape = (in_rank <= 1) ? ov::Shape{} : in_shape;
         if (in_rank > 1) {
-            out_shape.erase(out_shape.begin() + ((axis < 0) ? axis + (int64_t)in_rank : axis));
+            int64_t axis_norm = axis;
+            if (axis_norm < 0) axis_norm += static_cast<int64_t>(in_rank);
+            OPENVINO_ASSERT(axis_norm >= 0 && static_cast<size_t>(axis_norm) < in_rank,
+                            "ContribStringJoin axis out of range");
+            out_shape.erase(out_shape.begin() + static_cast<size_t>(axis_norm));
         }
         outputs[0].set_shape(out_shape);
         outputs[1].set_shape(out_shape);
@@ -220,6 +226,8 @@ bool ContribStringSplit::evaluate(ov::TensorVector& outputs,
     std::string delim = read_scalar_packed_string(inputs[3], inputs[4], inputs[5]);
     bool skip_empty;
     {
+        OPENVINO_ASSERT(inputs[6].get_size() == 1,
+                        "ContribStringSplit skip_empty input must be a scalar (single element)");
         const auto& st = inputs[6].get_element_type();
         if (st == element::boolean)
             skip_empty = inputs[6].data<const bool>()[0];

--- a/src/contrib_string_ops.cpp
+++ b/src/contrib_string_ops.cpp
@@ -31,6 +31,7 @@ std::string read_scalar_packed_string(const ov::Tensor& begins_t,
 }  // namespace
 
 void ContribStringJoin::validate_and_infer_types() {
+    OPENVINO_ASSERT(get_input_size() == 7, "ContribStringJoin expects 7 inputs");
     check_string_input(this, 0);
     check_string_input(this, 3);
     {
@@ -97,7 +98,11 @@ bool ContribStringJoin::evaluate(ov::TensorVector& outputs,
     }
 
     // Handle 0-D / single-string degenerate case: identity copy.
-    if (in_rank == 0 || ov::shape_size(in_shape) <= 1) {
+    // shape_size == 0 (empty input, e.g. [0,N]) must NOT enter this branch:
+    // the output still has N elements and only initialising index 0 would
+    // leave the rest of begins/ends uninitialized.  The general path handles
+    // axis_size == 0 correctly by producing N empty strings.
+    if (in_rank == 0 || ov::shape_size(in_shape) == 1) {
         ov::Shape out_shape = (in_rank <= 1) ? ov::Shape{} : in_shape;
         if (in_rank > 1) {
             out_shape.erase(out_shape.begin() + axis);
@@ -187,6 +192,7 @@ bool ContribStringJoin::evaluate(ov::TensorVector& outputs,
 }
 
 void ContribStringSplit::validate_and_infer_types() {
+    OPENVINO_ASSERT(get_input_size() == 7, "ContribStringSplit expects 7 inputs");
     check_string_input(this, 0);
     check_string_input(this, 3);
     {

--- a/src/contrib_string_ops.cpp
+++ b/src/contrib_string_ops.cpp
@@ -1,0 +1,319 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "contrib_string_ops.hpp"
+#include "utils.hpp"
+
+#include <algorithm>
+#include <string>
+#include <string_view>
+#include <vector>
+
+using namespace ov;
+
+namespace {
+
+// Read a single scalar string from a packed (begins, ends, chars) representation.
+std::string read_scalar_packed_string(const ov::Tensor& begins_t,
+                                      const ov::Tensor& ends_t,
+                                      const ov::Tensor& chars_t) {
+    OPENVINO_ASSERT(begins_t.get_size() >= 1,
+                    "Expected at least one element in packed string scalar");
+    auto begins = begins_t.data<const int32_t>();
+    auto ends   = ends_t.data<const int32_t>();
+    auto chars  = chars_t.data<const uint8_t>();
+    return std::string(reinterpret_cast<const char*>(chars + begins[0]),
+                       static_cast<size_t>(ends[0] - begins[0]));
+}
+
+}  // namespace
+
+void ContribStringJoin::validate_and_infer_types() {
+    check_string_input(this, 0);
+    check_string_input(this, 3);
+    {
+        auto t = get_input_element_type(6);
+        OPENVINO_ASSERT(t == element::i64 || t == element::i32 || t.is_dynamic(),
+                        "ContribStringJoin axis input must be of integer type, got: ", t);
+    }
+
+    auto in_pshape = get_input_partial_shape(0);
+    PartialShape out_pshape;
+    if (in_pshape.rank().is_static()) {
+        auto rank = in_pshape.rank().get_length();
+        if (rank <= 1) {
+            out_pshape = PartialShape{};
+        } else {
+            // Axis is generally not known statically; produce a dynamic
+            // shape one rank lower.
+            std::vector<Dimension> dims;
+            dims.reserve(rank - 1);
+            for (int64_t i = 0; i + 1 < rank; ++i) {
+                dims.emplace_back();
+            }
+            out_pshape = PartialShape(dims);
+        }
+    } else {
+        out_pshape = PartialShape::dynamic();
+    }
+
+    set_output_type(0, element::i32, out_pshape);
+    set_output_type(1, element::i32, out_pshape);
+    set_output_type(2, element::u8, PartialShape{Dimension()});
+}
+
+bool ContribStringJoin::evaluate(ov::TensorVector& outputs,
+                                 const ov::TensorVector& inputs) const {
+    OPENVINO_ASSERT(inputs.size() == 7, "ContribStringJoin expects 7 inputs");
+
+    auto begins = inputs[0].data<const int32_t>();
+    auto ends   = inputs[1].data<const int32_t>();
+    auto chars  = inputs[2].data<const uint8_t>();
+    const auto& in_shape = inputs[0].get_shape();
+    size_t in_rank = in_shape.size();
+
+    std::string sep = read_scalar_packed_string(inputs[3], inputs[4], inputs[5]);
+
+    int64_t axis;
+    {
+        const auto& at = inputs[6].get_element_type();
+        if (at == element::i64)
+            axis = inputs[6].data<const int64_t>()[0];
+        else if (at == element::i32)
+            axis = static_cast<int64_t>(inputs[6].data<const int32_t>()[0]);
+        else
+            OPENVINO_THROW("ContribStringJoin: unsupported axis element type ", at);
+    }
+
+    // Handle 0-D / single-string degenerate case: identity copy.
+    if (in_rank == 0 || ov::shape_size(in_shape) <= 1) {
+        ov::Shape out_shape = (in_rank <= 1) ? ov::Shape{} : in_shape;
+        if (in_rank > 1) {
+            out_shape.erase(out_shape.begin() + ((axis < 0) ? axis + (int64_t)in_rank : axis));
+        }
+        outputs[0].set_shape(out_shape);
+        outputs[1].set_shape(out_shape);
+
+        size_t total_in = (ov::shape_size(in_shape) == 0) ? 0
+                                                          : static_cast<size_t>(ends[0] - begins[0]);
+        outputs[2].set_shape(ov::Shape{total_in});
+        if (ov::shape_size(out_shape) >= 1) {
+            outputs[0].data<int32_t>()[0] = 0;
+            outputs[1].data<int32_t>()[0] = static_cast<int32_t>(total_in);
+            if (total_in > 0) {
+                std::copy(chars + begins[0], chars + ends[0],
+                          outputs[2].data<uint8_t>());
+            }
+        }
+        return true;
+    }
+
+    if (axis < 0) {
+        axis += static_cast<int64_t>(in_rank);
+    }
+    OPENVINO_ASSERT(axis >= 0 && static_cast<size_t>(axis) < in_rank,
+                    "ContribStringJoin axis out of range");
+
+    // Compute strides for input (row-major).
+    std::vector<size_t> in_strides(in_rank, 1);
+    for (int i = static_cast<int>(in_rank) - 2; i >= 0; --i) {
+        in_strides[i] = in_strides[i + 1] * in_shape[i + 1];
+    }
+
+    // Output shape = input shape with axis dimension removed.
+    ov::Shape out_shape;
+    out_shape.reserve(in_rank - 1);
+    for (size_t d = 0; d < in_rank; ++d) {
+        if (static_cast<int64_t>(d) != axis) {
+            out_shape.push_back(in_shape[d]);
+        }
+    }
+    size_t out_size = ov::shape_size(out_shape);
+    size_t axis_size = in_shape[axis];
+
+    // Output strides (over out_shape) for unraveling output linear index.
+    std::vector<size_t> out_strides(out_shape.size(), 1);
+    for (int i = static_cast<int>(out_shape.size()) - 2; i >= 0; --i) {
+        out_strides[i] = out_strides[i + 1] * out_shape[i + 1];
+    }
+
+    std::vector<std::string> result(out_size);
+    size_t total_chars = 0;
+    for (size_t oi = 0; oi < out_size; ++oi) {
+        // Unravel oi in out_shape order.
+        std::vector<size_t> coords_out(out_shape.size());
+        size_t r = oi;
+        for (size_t d = 0; d < out_shape.size(); ++d) {
+            coords_out[d] = r / out_strides[d];
+            r = r % out_strides[d];
+        }
+        // Map to base offset in input (axis coord = 0).
+        size_t base_offset = 0;
+        size_t k = 0;
+        for (size_t d = 0; d < in_rank; ++d) {
+            if (static_cast<int64_t>(d) == axis) continue;
+            base_offset += coords_out[k++] * in_strides[d];
+        }
+        std::string joined;
+        for (size_t a = 0; a < axis_size; ++a) {
+            size_t idx = base_offset + a * in_strides[axis];
+            if (a > 0) joined.append(sep);
+            joined.append(reinterpret_cast<const char*>(chars + begins[idx]),
+                          static_cast<size_t>(ends[idx] - begins[idx]));
+        }
+        total_chars += joined.size();
+        result[oi] = std::move(joined);
+    }
+
+    outputs[0].set_shape(out_shape);
+    outputs[1].set_shape(out_shape);
+    outputs[2].set_shape(ov::Shape{total_chars});
+    auto out_begins = outputs[0].data<int32_t>();
+    auto out_ends   = outputs[1].data<int32_t>();
+    auto out_chars  = outputs[2].data<uint8_t>();
+    size_t cur = 0;
+    for (size_t i = 0; i < out_size; ++i) {
+        out_begins[i] = static_cast<int32_t>(cur);
+        std::copy(result[i].begin(), result[i].end(), out_chars + cur);
+        cur += result[i].size();
+        out_ends[i] = static_cast<int32_t>(cur);
+    }
+    return true;
+}
+
+void ContribStringSplit::validate_and_infer_types() {
+    check_string_input(this, 0);
+    check_string_input(this, 3);
+    {
+        auto t = get_input_element_type(6);
+        OPENVINO_ASSERT(t == element::boolean || t == element::u8 || t == element::i8 || t.is_dynamic(),
+                        "ContribStringSplit skip_empty input must be of boolean/byte type, got: ", t);
+    }
+
+    auto in_pshape = get_input_partial_shape(0);
+    Dimension out_rank_dim;
+    if (in_pshape.rank().is_static()) {
+        out_rank_dim = Dimension(in_pshape.rank().get_length() + 1);
+    } else {
+        out_rank_dim = Dimension();
+    }
+    set_output_type(0, element::i64, PartialShape{Dimension(), out_rank_dim});
+    set_output_type(1, element::i32, PartialShape{Dimension()});
+    set_output_type(2, element::i32, PartialShape{Dimension()});
+    set_output_type(3, element::u8, PartialShape{Dimension()});
+    set_output_type(4, element::i64, PartialShape{out_rank_dim});
+}
+
+bool ContribStringSplit::evaluate(ov::TensorVector& outputs,
+                                  const ov::TensorVector& inputs) const {
+    OPENVINO_ASSERT(inputs.size() == 7, "ContribStringSplit expects 7 inputs");
+
+    auto begins = inputs[0].data<const int32_t>();
+    auto ends   = inputs[1].data<const int32_t>();
+    auto chars  = inputs[2].data<const uint8_t>();
+    const auto& in_shape = inputs[0].get_shape();
+    size_t in_rank = in_shape.size();
+    size_t in_size = ov::shape_size(in_shape);
+    size_t out_rank = in_rank + 1;
+
+    std::string delim = read_scalar_packed_string(inputs[3], inputs[4], inputs[5]);
+    bool skip_empty;
+    {
+        const auto& st = inputs[6].get_element_type();
+        if (st == element::boolean)
+            skip_empty = inputs[6].data<const bool>()[0];
+        else if (st == element::u8)
+            skip_empty = inputs[6].data<const uint8_t>()[0] != 0;
+        else if (st == element::i8)
+            skip_empty = inputs[6].data<const int8_t>()[0] != 0;
+        else
+            OPENVINO_THROW("ContribStringSplit: unsupported skip_empty element type ", st);
+    }
+
+    std::vector<size_t> in_strides(in_rank, 1);
+    for (int i = static_cast<int>(in_rank) - 2; i >= 0; --i) {
+        in_strides[i] = in_strides[i + 1] * in_shape[i + 1];
+    }
+
+    std::vector<int64_t> indices_flat;
+    std::vector<std::string> values;
+    size_t max_tokens = 0;
+
+    for (size_t p = 0; p < in_size; ++p) {
+        std::string_view s(reinterpret_cast<const char*>(chars + begins[p]),
+                           static_cast<size_t>(ends[p] - begins[p]));
+
+        std::vector<int64_t> coord(in_rank);
+        size_t r = p;
+        for (size_t d = 0; d < in_rank; ++d) {
+            coord[d] = static_cast<int64_t>(r / in_strides[d]);
+            r = r % in_strides[d];
+        }
+
+        std::vector<std::string_view> tokens;
+        if (delim.empty()) {
+            // Split into individual UTF-8 bytes (matches onnxruntime-extensions
+            // behavior of splitting on empty delimiter into characters).
+            tokens.reserve(s.size());
+            for (size_t i = 0; i < s.size(); ++i) {
+                tokens.emplace_back(s.data() + i, 1);
+            }
+        } else {
+            size_t pos = 0;
+            while (true) {
+                size_t found = s.find(delim, pos);
+                if (found == std::string_view::npos) {
+                    tokens.emplace_back(s.data() + pos, s.size() - pos);
+                    break;
+                }
+                tokens.emplace_back(s.data() + pos, found - pos);
+                pos = found + delim.size();
+            }
+        }
+
+        size_t tok_pos = 0;
+        for (auto& t : tokens) {
+            if (skip_empty && t.empty()) continue;
+            indices_flat.insert(indices_flat.end(), coord.begin(), coord.end());
+            indices_flat.push_back(static_cast<int64_t>(tok_pos));
+            values.emplace_back(t);
+            ++tok_pos;
+        }
+        if (tok_pos > max_tokens) max_tokens = tok_pos;
+    }
+
+    size_t N = values.size();
+
+    outputs[0].set_shape(ov::Shape{N, out_rank});
+    if (N > 0) {
+        std::copy(indices_flat.begin(), indices_flat.end(),
+                  outputs[0].data<int64_t>());
+    }
+
+    outputs[1].set_shape(ov::Shape{N});
+    outputs[2].set_shape(ov::Shape{N});
+    size_t total_chars = 0;
+    for (auto& v : values) total_chars += v.size();
+    outputs[3].set_shape(ov::Shape{total_chars});
+
+    auto vb = outputs[1].data<int32_t>();
+    auto ve = outputs[2].data<int32_t>();
+    auto vc = outputs[3].data<uint8_t>();
+    size_t cur = 0;
+    for (size_t i = 0; i < N; ++i) {
+        vb[i] = static_cast<int32_t>(cur);
+        std::copy(values[i].begin(), values[i].end(), vc + cur);
+        cur += values[i].size();
+        ve[i] = static_cast<int32_t>(cur);
+    }
+
+    outputs[4].set_shape(ov::Shape{out_rank});
+    auto ds = outputs[4].data<int64_t>();
+    for (size_t d = 0; d < in_rank; ++d) {
+        ds[d] = static_cast<int64_t>(in_shape[d]);
+    }
+    ds[in_rank] = static_cast<int64_t>(max_tokens);
+
+    return true;
+}

--- a/src/contrib_string_ops.cpp
+++ b/src/contrib_string_ops.cpp
@@ -10,6 +10,8 @@
 #include <string_view>
 #include <vector>
 
+#include <openvino/op/constant.hpp>
+
 using namespace ov;
 
 void ContribStringJoin::validate_and_infer_types() {
@@ -29,12 +31,22 @@ void ContribStringJoin::validate_and_infer_types() {
         if (rank <= 1) {
             out_pshape = PartialShape{};
         } else {
-            // Axis is generally not known statically; produce a dynamic
-            // shape one rank lower.
+            // Try to read axis as a constant so we can preserve known
+            // non-axis dimensions in the output shape (important for the
+            // CPU plugin which requires static shapes).
+            int64_t const_axis = -1;  // -1 means unknown at inference time
+            if (auto axis_const = ov::as_type_ptr<ov::op::v0::Constant>(
+                    input_value(4).get_node_shared_ptr())) {
+                const_axis = axis_const->cast_vector<int64_t>()[0];
+                if (const_axis < 0) const_axis += rank;
+            }
             std::vector<Dimension> dims;
             dims.reserve(rank - 1);
-            for (int64_t i = 0; i + 1 < rank; ++i) {
-                dims.emplace_back();
+            for (int64_t i = 0; i < rank; ++i) {
+                if (i == const_axis) continue;
+                // Preserve the known input dimension; fall back to dynamic
+                // if axis is not a compile-time constant.
+                dims.push_back(const_axis >= 0 ? in_pshape[i] : Dimension());
             }
             out_pshape = PartialShape(dims);
         }

--- a/src/contrib_string_ops.cpp
+++ b/src/contrib_string_ops.cpp
@@ -12,30 +12,12 @@
 
 using namespace ov;
 
-namespace {
-
-// Read a single scalar string from a packed (begins, ends, chars) representation.
-std::string read_scalar_packed_string(const ov::Tensor& begins_t,
-                                      const ov::Tensor& ends_t,
-                                      const ov::Tensor& chars_t) {
-    OPENVINO_ASSERT(begins_t.get_size() == 1 && ends_t.get_size() == 1,
-                    "Expected a scalar packed string (single begins/ends element)");
-    auto begins = begins_t.data<const int32_t>();
-    auto ends   = ends_t.data<const int32_t>();
-    auto chars  = chars_t.data<const uint8_t>();
-    OPENVINO_ASSERT(ends[0] >= begins[0], "Malformed packed string: ends[0] < begins[0]");
-    return std::string(reinterpret_cast<const char*>(chars + begins[0]),
-                       static_cast<size_t>(ends[0] - begins[0]));
-}
-
-}  // namespace
-
 void ContribStringJoin::validate_and_infer_types() {
-    OPENVINO_ASSERT(get_input_size() == 7, "ContribStringJoin expects 7 inputs");
+    OPENVINO_ASSERT(get_input_size() == 5, "ContribStringJoin expects 5 inputs");
     check_string_input(this, 0);
-    check_string_input(this, 3);
+    check_string_scalar_input(this, 3);
     {
-        auto t = get_input_element_type(6);
+        auto t = get_input_element_type(4);
         OPENVINO_ASSERT(t == element::i64 || t == element::i32 || t.is_dynamic(),
                         "ContribStringJoin axis input must be of integer type, got: ", t);
     }
@@ -67,7 +49,7 @@ void ContribStringJoin::validate_and_infer_types() {
 
 bool ContribStringJoin::evaluate(ov::TensorVector& outputs,
                                  const ov::TensorVector& inputs) const {
-    OPENVINO_ASSERT(inputs.size() == 7, "ContribStringJoin expects 7 inputs");
+    OPENVINO_ASSERT(inputs.size() == 5, "ContribStringJoin expects 5 inputs");
 
     auto begins = inputs[0].data<const int32_t>();
     auto ends   = inputs[1].data<const int32_t>();
@@ -75,17 +57,18 @@ bool ContribStringJoin::evaluate(ov::TensorVector& outputs,
     const auto& in_shape = inputs[0].get_shape();
     size_t in_rank = in_shape.size();
 
-    std::string sep = read_scalar_packed_string(inputs[3], inputs[4], inputs[5]);
+    std::string_view sep(reinterpret_cast<const char*>(inputs[3].data<const uint8_t>()),
+                         inputs[3].get_size());
 
     int64_t axis;
     {
-        OPENVINO_ASSERT(inputs[6].get_size() == 1,
+        OPENVINO_ASSERT(inputs[4].get_size() == 1,
                         "ContribStringJoin axis input must be a scalar (single element)");
-        const auto& at = inputs[6].get_element_type();
+        const auto& at = inputs[4].get_element_type();
         if (at == element::i64)
-            axis = inputs[6].data<const int64_t>()[0];
+            axis = inputs[4].data<const int64_t>()[0];
         else if (at == element::i32)
-            axis = static_cast<int64_t>(inputs[6].data<const int32_t>()[0]);
+            axis = static_cast<int64_t>(inputs[4].data<const int32_t>()[0]);
         else
             OPENVINO_THROW("ContribStringJoin: unsupported axis element type ", at);
     }
@@ -147,32 +130,31 @@ bool ContribStringJoin::evaluate(ov::TensorVector& outputs,
         out_strides[i] = out_strides[i + 1] * out_shape[i + 1];
     }
 
-    std::vector<std::string> result(out_size);
-    size_t total_chars = 0;
+    // Helper: unravel output linear index to compute input base offset.
     std::vector<size_t> coords_out(out_shape.size());
-    for (size_t oi = 0; oi < out_size; ++oi) {
-        // Unravel oi in out_shape order.
+    auto compute_base_offset = [&](size_t oi) -> size_t {
         size_t r = oi;
         for (size_t d = 0; d < out_shape.size(); ++d) {
             coords_out[d] = r / out_strides[d];
             r = r % out_strides[d];
         }
-        // Map to base offset in input (axis coord = 0).
-        size_t base_offset = 0;
-        size_t k = 0;
+        size_t base = 0, k = 0;
         for (size_t d = 0; d < in_rank; ++d) {
             if (static_cast<int64_t>(d) == axis) continue;
-            base_offset += coords_out[k++] * in_strides[d];
+            base += coords_out[k++] * in_strides[d];
         }
-        std::string joined;
+        return base;
+    };
+
+    // Pass 1: compute total output chars to pre-size the output buffer.
+    size_t total_chars = 0;
+    for (size_t oi = 0; oi < out_size; ++oi) {
+        size_t base = compute_base_offset(oi);
         for (size_t a = 0; a < axis_size; ++a) {
-            size_t idx = base_offset + a * in_strides[axis];
-            if (a > 0) joined.append(sep);
-            joined.append(reinterpret_cast<const char*>(chars + begins[idx]),
-                          static_cast<size_t>(ends[idx] - begins[idx]));
+            size_t idx = base + a * in_strides[axis];
+            if (a > 0) total_chars += sep.size();
+            total_chars += static_cast<size_t>(ends[idx] - begins[idx]);
         }
-        total_chars += joined.size();
-        result[oi] = std::move(joined);
     }
 
     outputs[0].set_shape(out_shape);
@@ -181,22 +163,33 @@ bool ContribStringJoin::evaluate(ov::TensorVector& outputs,
     auto out_begins = outputs[0].data<int32_t>();
     auto out_ends   = outputs[1].data<int32_t>();
     auto out_chars  = outputs[2].data<uint8_t>();
+
+    // Pass 2: write joined strings directly to the output buffer.
     size_t cur = 0;
-    for (size_t i = 0; i < out_size; ++i) {
-        out_begins[i] = static_cast<int32_t>(cur);
-        std::copy(result[i].begin(), result[i].end(), out_chars + cur);
-        cur += result[i].size();
-        out_ends[i] = static_cast<int32_t>(cur);
+    for (size_t oi = 0; oi < out_size; ++oi) {
+        out_begins[oi] = static_cast<int32_t>(cur);
+        size_t base = compute_base_offset(oi);
+        for (size_t a = 0; a < axis_size; ++a) {
+            size_t idx = base + a * in_strides[axis];
+            if (a > 0) {
+                std::copy(sep.data(), sep.data() + sep.size(), out_chars + cur);
+                cur += sep.size();
+            }
+            size_t slen = static_cast<size_t>(ends[idx] - begins[idx]);
+            std::copy(chars + begins[idx], chars + ends[idx], out_chars + cur);
+            cur += slen;
+        }
+        out_ends[oi] = static_cast<int32_t>(cur);
     }
     return true;
 }
 
 void ContribStringSplit::validate_and_infer_types() {
-    OPENVINO_ASSERT(get_input_size() == 7, "ContribStringSplit expects 7 inputs");
+    OPENVINO_ASSERT(get_input_size() == 5, "ContribStringSplit expects 5 inputs");
     check_string_input(this, 0);
-    check_string_input(this, 3);
+    check_string_scalar_input(this, 3);
     {
-        auto t = get_input_element_type(6);
+        auto t = get_input_element_type(4);
         OPENVINO_ASSERT(t == element::boolean || t == element::u8 || t == element::i8 || t.is_dynamic(),
                         "ContribStringSplit skip_empty input must be of boolean/byte type, got: ", t);
     }
@@ -217,7 +210,7 @@ void ContribStringSplit::validate_and_infer_types() {
 
 bool ContribStringSplit::evaluate(ov::TensorVector& outputs,
                                   const ov::TensorVector& inputs) const {
-    OPENVINO_ASSERT(inputs.size() == 7, "ContribStringSplit expects 7 inputs");
+    OPENVINO_ASSERT(inputs.size() == 5, "ContribStringSplit expects 5 inputs");
 
     auto begins = inputs[0].data<const int32_t>();
     auto ends   = inputs[1].data<const int32_t>();
@@ -227,18 +220,19 @@ bool ContribStringSplit::evaluate(ov::TensorVector& outputs,
     size_t in_size = ov::shape_size(in_shape);
     size_t out_rank = in_rank + 1;
 
-    std::string delim = read_scalar_packed_string(inputs[3], inputs[4], inputs[5]);
+    std::string_view delim(reinterpret_cast<const char*>(inputs[3].data<const uint8_t>()),
+                           inputs[3].get_size());
     bool skip_empty;
     {
-        OPENVINO_ASSERT(inputs[6].get_size() == 1,
+        OPENVINO_ASSERT(inputs[4].get_size() == 1,
                         "ContribStringSplit skip_empty input must be a scalar (single element)");
-        const auto& st = inputs[6].get_element_type();
+        const auto& st = inputs[4].get_element_type();
         if (st == element::boolean)
-            skip_empty = inputs[6].data<const bool>()[0];
+            skip_empty = inputs[4].data<const bool>()[0];
         else if (st == element::u8)
-            skip_empty = inputs[6].data<const uint8_t>()[0] != 0;
+            skip_empty = inputs[4].data<const uint8_t>()[0] != 0;
         else if (st == element::i8)
-            skip_empty = inputs[6].data<const int8_t>()[0] != 0;
+            skip_empty = inputs[4].data<const int8_t>()[0] != 0;
         else
             OPENVINO_THROW("ContribStringSplit: unsupported skip_empty element type ", st);
     }

--- a/src/contrib_string_ops.cpp
+++ b/src/contrib_string_ops.cpp
@@ -123,6 +123,7 @@ bool ContribStringJoin::evaluate(ov::TensorVector& outputs,
     }
     size_t out_size = ov::shape_size(out_shape);
     size_t axis_size = in_shape[axis];
+    const size_t axis_stride = in_strides[axis];
 
     // Output strides (over out_shape) for unraveling output linear index.
     std::vector<size_t> out_strides(out_shape.size(), 1);
@@ -147,12 +148,13 @@ bool ContribStringJoin::evaluate(ov::TensorVector& outputs,
     };
 
     // Pass 1: compute total output chars to pre-size the output buffer.
-    size_t total_chars = 0;
+    // Pre-count all separators: each of the out_size joined strings contains
+    // (axis_size - 1) separators.  Guard against axis_size == 0 (size_t underflow).
+    size_t total_chars = (axis_size > 0) ? out_size * (axis_size - 1) * sep.size() : 0;
     for (size_t oi = 0; oi < out_size; ++oi) {
         size_t base = compute_base_offset(oi);
         for (size_t a = 0; a < axis_size; ++a) {
-            size_t idx = base + a * in_strides[axis];
-            if (a > 0) total_chars += sep.size();
+            size_t idx = base + a * axis_stride;
             total_chars += static_cast<size_t>(ends[idx] - begins[idx]);
         }
     }
@@ -170,7 +172,7 @@ bool ContribStringJoin::evaluate(ov::TensorVector& outputs,
         out_begins[oi] = static_cast<int32_t>(cur);
         size_t base = compute_base_offset(oi);
         for (size_t a = 0; a < axis_size; ++a) {
-            size_t idx = base + a * in_strides[axis];
+            size_t idx = base + a * axis_stride;
             if (a > 0) {
                 std::copy(sep.data(), sep.data() + sep.size(), out_chars + cur);
                 cur += sep.size();

--- a/src/contrib_string_ops.hpp
+++ b/src/contrib_string_ops.hpp
@@ -13,8 +13,8 @@
 //   0: input begins   (i32, tensor shape S)
 //   1: input ends     (i32, tensor shape S)
 //   2: input chars    (u8,  1D)
-//   3: sep begins     (i32, 1D, expects single element)
-//   4: sep ends       (i32, 1D, expects single element)
+//   3: sep begins     (i32, 0D/1D, single element)
+//   4: sep ends       (i32, 0D/1D, single element)
 //   5: sep chars      (u8,  1D)
 //   6: axis           (i64, 0-D or 1-D single element)
 //
@@ -55,8 +55,8 @@ public:
 //   0: input begins     (i32, tensor shape S)
 //   1: input ends       (i32, tensor shape S)
 //   2: input chars      (u8,  1D)
-//   3: delim begins     (i32, 1D, single element)
-//   4: delim ends       (i32, 1D, single element)
+//   3: delim begins     (i32, 0D/1D, single element)
+//   4: delim ends       (i32, 0D/1D, single element)
 //   5: delim chars      (u8,  1D)
 //   6: skip_empty       (bool, 0-D or 1-D single element)
 //

--- a/src/contrib_string_ops.hpp
+++ b/src/contrib_string_ops.hpp
@@ -13,10 +13,8 @@
 //   0: input begins   (i32, tensor shape S)
 //   1: input ends     (i32, tensor shape S)
 //   2: input chars    (u8,  1D)
-//   3: sep begins     (i32, 0D/1D, single element)
-//   4: sep ends       (i32, 0D/1D, single element)
-//   5: sep chars      (u8,  1D)
-//   6: axis           (i64, 0-D or 1-D single element)
+//   3: sep chars      (u8,  1D raw bytes of the separator string)
+//   4: axis           (i64, 0-D or 1-D single element)
 //
 // Outputs:
 //   0: out begins (i32, shape = S with axis removed; scalar shape {} if rank==1)
@@ -55,10 +53,8 @@ public:
 //   0: input begins     (i32, tensor shape S)
 //   1: input ends       (i32, tensor shape S)
 //   2: input chars      (u8,  1D)
-//   3: delim begins     (i32, 0D/1D, single element)
-//   4: delim ends       (i32, 0D/1D, single element)
-//   5: delim chars      (u8,  1D)
-//   6: skip_empty       (bool, 0-D or 1-D single element)
+//   3: delim chars      (u8,  1D raw bytes of the delimiter string)
+//   4: skip_empty       (bool, 0-D or 1-D single element)
 //
 // Outputs:
 //   0: sparse indices   (i64, shape [N, rank+1])

--- a/src/contrib_string_ops.hpp
+++ b/src/contrib_string_ops.hpp
@@ -1,0 +1,90 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <openvino/op/op.hpp>
+
+// ai.onnx.contrib.StringJoin equivalent. Joins string elements of a decomposed
+// (begins, ends, chars) string tensor along `axis` using a scalar `sep`.
+//
+// Inputs (in order):
+//   0: input begins   (i32, tensor shape S)
+//   1: input ends     (i32, tensor shape S)
+//   2: input chars    (u8,  1D)
+//   3: sep begins     (i32, 1D, expects single element)
+//   4: sep ends       (i32, 1D, expects single element)
+//   5: sep chars      (u8,  1D)
+//   6: axis           (i64, 0-D or 1-D single element)
+//
+// Outputs:
+//   0: out begins (i32, shape = S with axis removed; scalar shape {} if rank==1)
+//   1: out ends   (i32, same shape)
+//   2: out chars  (u8,  1D)
+class ContribStringJoin : public ov::op::Op {
+public:
+    OPENVINO_OP("ContribStringJoin");
+
+    ContribStringJoin() = default;
+
+    ContribStringJoin(const ov::OutputVector& arguments) : ov::op::Op(arguments) {
+        constructor_validate_and_infer_types();
+    }
+
+    void validate_and_infer_types() override;
+
+    std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& inputs) const override {
+        return std::make_shared<ContribStringJoin>(inputs);
+    }
+
+    bool visit_attributes(ov::AttributeVisitor& /*visitor*/) override { return true; }
+
+    bool evaluate(ov::TensorVector& outputs, const ov::TensorVector& inputs) const override;
+
+    bool has_evaluate() const override { return true; }
+};
+
+
+// ai.onnx.contrib.StringSplit equivalent. Splits each string of a decomposed
+// (begins, ends, chars) string tensor by a scalar `delimiter`. Produces a
+// sparse-tensor-like representation with rank = input_rank + 1, where the
+// trailing axis is the position of the split token.
+//
+// Inputs (in order):
+//   0: input begins     (i32, tensor shape S)
+//   1: input ends       (i32, tensor shape S)
+//   2: input chars      (u8,  1D)
+//   3: delim begins     (i32, 1D, single element)
+//   4: delim ends       (i32, 1D, single element)
+//   5: delim chars      (u8,  1D)
+//   6: skip_empty       (bool, 0-D or 1-D single element)
+//
+// Outputs:
+//   0: sparse indices   (i64, shape [N, rank+1])
+//   1: values begins    (i32, shape [N])
+//   2: values ends      (i32, shape [N])
+//   3: values chars     (u8,  1D)
+//   4: dense shape      (i64, shape [rank+1])
+class ContribStringSplit : public ov::op::Op {
+public:
+    OPENVINO_OP("ContribStringSplit");
+
+    ContribStringSplit() = default;
+
+    ContribStringSplit(const ov::OutputVector& arguments) : ov::op::Op(arguments) {
+        constructor_validate_and_infer_types();
+    }
+
+    void validate_and_infer_types() override;
+
+    std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& inputs) const override {
+        return std::make_shared<ContribStringSplit>(inputs);
+    }
+
+    bool visit_attributes(ov::AttributeVisitor& /*visitor*/) override { return true; }
+
+    bool evaluate(ov::TensorVector& outputs, const ov::TensorVector& inputs) const override;
+
+    bool has_evaluate() const override { return true; }
+};

--- a/src/onnx_translators.cpp
+++ b/src/onnx_translators.cpp
@@ -344,14 +344,14 @@ namespace {
 template <typename T>
 T extract_scalar_const(const ov::Output<ov::Node> &input,
                        const std::string &name) {
-    auto const_node =
-        ov::as_type_ptr<Constant>(input.get_node_shared_ptr());
-    FRONT_END_GENERAL_CHECK(const_node,
-        "[ONNX Frontend] expected constant for ", name);
-    auto values = const_node->cast_vector<T>();
-    FRONT_END_GENERAL_CHECK(values.size() == 1,
-        "[ONNX Frontend] expected scalar for ", name);
-    return values[0];
+  auto const_node =
+      ov::as_type_ptr<Constant>(input.get_node_shared_ptr());
+  FRONT_END_GENERAL_CHECK(const_node,
+      "[ONNX Frontend] expected constant for ", name);
+  auto values = const_node->cast_vector<T>();
+  FRONT_END_GENERAL_CHECK(values.size() == 1,
+      "[ONNX Frontend] expected scalar for ", name);
+  return values[0];
 }
 
 // Build an OV graph that converts the SentencepieceTokenizer OV op's sparse
@@ -363,38 +363,38 @@ ov::OutputVector make_row_splits_from_sparse(
     const ov::Output<ov::Node> &sparse_indices,
     const ov::Output<ov::Node> &sparse_values,
     const ov::Output<ov::Node> &dense_shape) {
-    auto axis0_1d = std::make_shared<Constant>(element::i64, Shape{1},
-                                               std::vector<int64_t>{0});
-    auto axis1_1d = std::make_shared<Constant>(element::i64, Shape{1},
-                                               std::vector<int64_t>{1});
-    auto axis0_0d = std::make_shared<Constant>(element::i64, Shape{},
-                                               std::vector<int64_t>{0});
+  auto axis0_1d = std::make_shared<Constant>(element::i64, Shape{1},
+                                             std::vector<int64_t>{0});
+  auto axis1_1d = std::make_shared<Constant>(element::i64, Shape{1},
+                                             std::vector<int64_t>{1});
+  auto axis0_0d = std::make_shared<Constant>(element::i64, Shape{},
+                                             std::vector<int64_t>{0});
 
-    // batch_indices = sparse_indices[:, 0], shape [N]
-    auto batch_indices =
-        std::make_shared<Gather>(sparse_indices, axis0_0d, axis1_1d);
+  // batch_indices = sparse_indices[:, 0], shape [N]
+  auto batch_indices =
+      std::make_shared<Gather>(sparse_indices, axis0_0d, axis1_1d);
 
-    // B = dense_shape[0], scalar i64
-    auto B = std::make_shared<Gather>(dense_shape, axis0_0d, axis0_0d);
+  // B = dense_shape[0], scalar i64
+  auto B = std::make_shared<Gather>(dense_shape, axis0_0d, axis0_0d);
 
-    // range = [0, B+1)
-    auto one_i64 = std::make_shared<Constant>(element::i64, Shape{},
-                                              std::vector<int64_t>{1});
-    auto B_plus_1 = std::make_shared<Add>(B, one_i64);
-    auto zero_i64 = std::make_shared<Constant>(element::i64, Shape{},
-                                               std::vector<int64_t>{0});
-    auto range =
-        std::make_shared<Range>(zero_i64, B_plus_1, one_i64, element::i64);
+  // range = [0, B+1)
+  auto one_i64 = std::make_shared<Constant>(element::i64, Shape{},
+                                            std::vector<int64_t>{1});
+  auto B_plus_1 = std::make_shared<Add>(B, one_i64);
+  auto zero_i64 = std::make_shared<Constant>(element::i64, Shape{},
+                                             std::vector<int64_t>{0});
+  auto range =
+      std::make_shared<Range>(zero_i64, B_plus_1, one_i64, element::i64);
 
-    // mask[n, i] = batch_indices[n] < range[i]
-    auto bi_unsq = std::make_shared<Unsqueeze>(batch_indices, axis1_1d);
-    auto range_unsq = std::make_shared<Unsqueeze>(range, axis0_1d);
-    auto mask = std::make_shared<Less>(bi_unsq, range_unsq);
-    auto mask_i64 = std::make_shared<Convert>(mask, element::i64);
-    auto row_splits =
-        std::make_shared<ReduceSum>(mask_i64, axis0_1d, false)->output(0);
+  // mask[n, i] = batch_indices[n] < range[i]
+  auto bi_unsq = std::make_shared<Unsqueeze>(batch_indices, axis1_1d);
+  auto range_unsq = std::make_shared<Unsqueeze>(range, axis0_1d);
+  auto mask = std::make_shared<Less>(bi_unsq, range_unsq);
+  auto mask_i64 = std::make_shared<Convert>(mask, element::i64);
+  auto row_splits =
+      std::make_shared<ReduceSum>(mask_i64, axis0_1d, false)->output(0);
 
-    return {sparse_values, row_splits};
+  return {sparse_values, row_splits};
 }
 
 }  // namespace
@@ -590,7 +590,7 @@ translate_onnx_contrib_string_join(const ov::frontend::NodeContext &node) {
 
     OutputVector args;
     args.insert(args.end(), input_unpacked.begin(), input_unpacked.end());
-    args.insert(args.end(), sep_unpacked.begin(), sep_unpacked.end());
+    args.push_back(sep_unpacked[2]);  // pass sep raw chars (u8) directly
     args.push_back(axis_i64);
 
     auto join = std::make_shared<ContribStringJoin>(args);
@@ -619,7 +619,7 @@ translate_onnx_contrib_string_split(const ov::frontend::NodeContext &node) {
 
     OutputVector args;
     args.insert(args.end(), input_unpacked.begin(), input_unpacked.end());
-    args.insert(args.end(), delim_unpacked.begin(), delim_unpacked.end());
+    args.push_back(delim_unpacked[2]);  // pass delim raw chars (u8) directly
     args.push_back(skip_bool);
 
     auto split = std::make_shared<ContribStringSplit>(args);

--- a/src/onnx_translators.cpp
+++ b/src/onnx_translators.cpp
@@ -8,6 +8,7 @@
 #include "utils.hpp"
 
 #include "case_fold.hpp"
+#include "contrib_string_ops.hpp"
 #include "equal_str.hpp"
 #include "fuze.hpp"
 #include "normalize_unicode.hpp"
@@ -16,6 +17,7 @@
 #include "ragged_to_dense.hpp"
 #include "regex_normalization.hpp"
 #include "regex_split.hpp"
+#include "sentence_piece.hpp"
 #include "string_tensor_pack.hpp"
 #include "string_tensor_unpack.hpp"
 #include "string_to_hash_bucket.hpp"
@@ -333,4 +335,302 @@ translate_onnx_tfid_vectorizer(const ov::frontend::NodeContext &node) {
   set_node_name(node_name, tf_counts.get_node_shared_ptr());
 
   return {tf_counts};
+}
+
+namespace {
+
+// Extract a scalar value of type T from a constant input. Helper mirrored after
+// the tensorflow translator's extract_scalar_const_value.
+template <typename T>
+T extract_scalar_const(const ov::Output<ov::Node> &input,
+                       const std::string &name) {
+    auto const_node =
+        ov::as_type_ptr<Constant>(input.get_node_shared_ptr());
+    FRONT_END_GENERAL_CHECK(const_node,
+        "[ONNX Frontend] expected constant for ", name);
+    auto values = const_node->cast_vector<T>();
+    FRONT_END_GENERAL_CHECK(values.size() == 1,
+        "[ONNX Frontend] expected scalar for ", name);
+    return values[0];
+}
+
+// Build an OV graph that converts the SentencepieceTokenizer OV op's sparse
+// outputs (indices [N, 2], values [N] i32, dense_shape [2] i64) into the
+// onnxruntime-extensions style outputs:
+//   - flat token ids (i32, 1D)
+//   - row split indices (i64, 1D length batch_size + 1)
+ov::OutputVector make_row_splits_from_sparse(
+    const ov::Output<ov::Node> &sparse_indices,
+    const ov::Output<ov::Node> &sparse_values,
+    const ov::Output<ov::Node> &dense_shape) {
+    auto axis0_1d = std::make_shared<Constant>(element::i64, Shape{1},
+                                               std::vector<int64_t>{0});
+    auto axis1_1d = std::make_shared<Constant>(element::i64, Shape{1},
+                                               std::vector<int64_t>{1});
+    auto axis0_0d = std::make_shared<Constant>(element::i64, Shape{},
+                                               std::vector<int64_t>{0});
+
+    // batch_indices = sparse_indices[:, 0], shape [N]
+    auto batch_indices =
+        std::make_shared<Gather>(sparse_indices, axis0_0d, axis1_1d);
+
+    // B = dense_shape[0], scalar i64
+    auto B = std::make_shared<Gather>(dense_shape, axis0_0d, axis0_0d);
+
+    // range = [0, B+1)
+    auto one_i64 = std::make_shared<Constant>(element::i64, Shape{},
+                                              std::vector<int64_t>{1});
+    auto B_plus_1 = std::make_shared<Add>(B, one_i64);
+    auto zero_i64 = std::make_shared<Constant>(element::i64, Shape{},
+                                               std::vector<int64_t>{0});
+    auto range =
+        std::make_shared<Range>(zero_i64, B_plus_1, one_i64, element::i64);
+
+    // mask[n, i] = batch_indices[n] < range[i]
+    auto bi_unsq = std::make_shared<Unsqueeze>(batch_indices, axis1_1d);
+    auto range_unsq = std::make_shared<Unsqueeze>(range, axis0_1d);
+    auto mask = std::make_shared<Less>(bi_unsq, range_unsq);
+    auto mask_i64 = std::make_shared<Convert>(mask, element::i64);
+    auto row_splits =
+        std::make_shared<ReduceSum>(mask_i64, axis0_1d, false)->output(0);
+
+    return {sparse_values, row_splits};
+}
+
+}  // namespace
+
+ov::OutputVector
+translate_onnx_contrib_sentencepiece_tokenizer(
+    const ov::frontend::NodeContext &node) {
+    auto node_name = node.get_name();
+    FRONT_END_GENERAL_CHECK(node.get_input_size() == 6 || node.get_input_size() == 7,
+        "ai.onnx.contrib.SentencepieceTokenizer expects 6 or 7 inputs "
+        "(input, nbest_size, alpha, add_bos, add_eos, reverse[, fairseq])");
+    FRONT_END_GENERAL_CHECK(node.has_attribute("model"),
+        "ai.onnx.contrib.SentencepieceTokenizer requires the 'model' attribute");
+
+    auto model_bytes = node.get_attribute<std::string>("model");
+    auto sp_model_const = std::make_shared<Constant>(
+        element::u8, Shape{model_bytes.size()},
+        reinterpret_cast<const void *>(model_bytes.data()));
+
+    auto input_strings = node.get_input(0);
+    auto nbest_size =
+        extract_scalar_const<int32_t>(node.get_input(1), "nbest_size");
+    auto alpha = extract_scalar_const<float>(node.get_input(2), "alpha");
+    auto add_bos = extract_scalar_const<bool>(node.get_input(3), "add_bos");
+    auto add_eos = extract_scalar_const<bool>(node.get_input(4), "add_eos");
+    auto reverse = extract_scalar_const<bool>(node.get_input(5), "reverse");
+    // The optional 7th input enables fairseq-style id remapping, which the
+    // underlying SentencepieceTokenizer op does not implement.
+    if (node.get_input_size() == 7) {
+        auto fairseq = extract_scalar_const<bool>(node.get_input(6), "fairseq");
+        FRONT_END_GENERAL_CHECK(!fairseq,
+            "ai.onnx.contrib.SentencepieceTokenizer does not support fairseq mode");
+    }
+
+    auto sp_tokenizer = std::make_shared<SentencepieceTokenizer>(
+        OutputVector{sp_model_const, input_strings},
+        nbest_size, alpha, add_bos, add_eos, reverse);
+    FRONT_END_GENERAL_CHECK(sp_tokenizer->get_output_size() == 3,
+        "SentencepieceTokenizer must produce three outputs");
+
+    auto outs = make_row_splits_from_sparse(
+        sp_tokenizer->output(0),  // sparse_indices i64 [N,2]
+        sp_tokenizer->output(1),  // sparse_values  i32 [N]
+        sp_tokenizer->output(2)); // dense_shape    i64 [2]
+
+    outs[0].add_names({node_name + ":0"});
+    outs[1].add_names({node_name + ":1"});
+    return outs;
+}
+
+ov::OutputVector
+translate_onnx_contrib_sentencepiece_decoder(
+    const ov::frontend::NodeContext &node) {
+    auto node_name = node.get_name();
+    FRONT_END_GENERAL_CHECK(node.get_input_size() == 2,
+        "ai.onnx.contrib.SentencepieceDecoder expects 2 inputs (token ids, fairseq)");
+    FRONT_END_GENERAL_CHECK(node.has_attribute("model"),
+        "ai.onnx.contrib.SentencepieceDecoder requires the 'model' attribute");
+    // The optional fairseq flag enables fairseq-style id remapping, which the
+    // underlying SentencepieceDetokenizer op does not implement.
+    auto fairseq = extract_scalar_const<bool>(node.get_input(1), "fairseq");
+    FRONT_END_GENERAL_CHECK(!fairseq,
+        "ai.onnx.contrib.SentencepieceDecoder does not support fairseq mode");
+
+    auto model_bytes = node.get_attribute<std::string>("model");
+    auto sp_model_const = std::make_shared<Constant>(
+        element::u8, Shape{model_bytes.size()},
+        reinterpret_cast<const void *>(model_bytes.data()));
+
+    // SentencepieceDetokenizer expects a 2D [batch, seq_len] i32 tensor of ids.
+    auto token_ids = std::make_shared<Convert>(node.get_input(0), element::i32);
+    auto sp_detokenizer = std::make_shared<SentencepieceDetokenizer>(
+        OutputVector{sp_model_const, token_ids});
+    FRONT_END_GENERAL_CHECK(sp_detokenizer->get_output_size() == 3,
+        "SentencepieceDetokenizer must produce three outputs");
+
+    auto str_out = post_translate_string_tensor_output(sp_detokenizer->outputs());
+    str_out.add_names({node_name + ":0"});
+    return {str_out};
+}
+
+namespace {
+
+// Parse the `map` attribute of ai.onnx.contrib.VectorToString. Each non-empty
+// line has the format "<token>\t<id>". Returns the vocabulary in id order
+// (filled with `unk` for missing ids in [0, max_id]).
+std::vector<std::string> parse_vector_to_string_map(
+    const std::string &text, const std::string &unk) {
+    std::vector<std::pair<std::string, int64_t>> pairs;
+    int64_t max_id = -1;
+    size_t pos = 0;
+    while (pos < text.size()) {
+        size_t nl = text.find('\n', pos);
+        if (nl == std::string::npos) nl = text.size();
+        if (nl > pos) {
+            auto tab = text.find('\t', pos);
+            if (tab != std::string::npos && tab < nl) {
+                std::string token = text.substr(pos, tab - pos);
+                std::string id_str = text.substr(tab + 1, nl - tab - 1);
+                // Strip trailing CR if present.
+                if (!id_str.empty() && id_str.back() == '\r') id_str.pop_back();
+                try {
+                    int64_t id = std::stoll(id_str);
+                    if (id >= 0) {
+                        pairs.emplace_back(std::move(token), id);
+                        if (id > max_id) max_id = id;
+                    }
+                } catch (...) {
+                    // Skip malformed line.
+                }
+            }
+        }
+        pos = nl + 1;
+    }
+    std::vector<std::string> vocab(static_cast<size_t>(max_id + 1), unk);
+    for (auto &p : pairs) {
+        vocab[static_cast<size_t>(p.second)] = std::move(p.first);
+    }
+    return vocab;
+}
+
+}  // namespace
+
+ov::OutputVector
+translate_onnx_contrib_vector_to_string(
+    const ov::frontend::NodeContext &node) {
+    auto node_name = node.get_name();
+    FRONT_END_GENERAL_CHECK(node.get_input_size() == 1,
+        "ai.onnx.contrib.VectorToString expects 1 input (token ids)");
+    FRONT_END_GENERAL_CHECK(node.has_attribute("map"),
+        "ai.onnx.contrib.VectorToString requires the 'map' attribute");
+
+    auto map_text = node.get_attribute<std::string>("map");
+    auto unk = node.get_attribute<std::string>("unk", std::string{});
+
+    auto vocab = parse_vector_to_string_map(map_text, unk);
+    size_t vocab_size = vocab.size();
+    FRONT_END_GENERAL_CHECK(vocab_size > 0,
+        "ai.onnx.contrib.VectorToString: parsed empty map");
+    // Append unk as a sentinel slot so out-of-range ids can be mapped to it
+    // purely via integer Select+Gather (CPU plugin does not support Select on
+    // string tensors).
+    vocab.push_back(unk);
+    size_t vocab_size_with_unk = vocab.size();
+
+    auto vocab_const = std::make_shared<Constant>(
+        element::string, Shape{vocab_size_with_unk}, vocab);
+
+    // Lookup: ids may be i64 or i32 in the source model. Cast to i64 and map
+    // out-of-range ids to the sentinel unk slot.
+    auto ids = node.get_input(0);
+    auto ids_i64 = std::make_shared<Convert>(ids, element::i64);
+    auto vocab_size_const = std::make_shared<Constant>(
+        element::i64, Shape{},
+        std::vector<int64_t>{static_cast<int64_t>(vocab_size)});
+    auto zero_i64 = std::make_shared<Constant>(element::i64, Shape{},
+                                               std::vector<int64_t>{0});
+    auto unk_idx_const = std::make_shared<Constant>(
+        element::i64, Shape{},
+        std::vector<int64_t>{static_cast<int64_t>(vocab_size)});  // last slot
+
+    auto in_range_hi = std::make_shared<Less>(ids_i64, vocab_size_const);
+    auto in_range_lo = std::make_shared<GreaterEqual>(ids_i64, zero_i64);
+    auto in_range = std::make_shared<LogicalAnd>(in_range_hi, in_range_lo);
+
+    auto safe_ids = std::make_shared<Select>(in_range, ids_i64, unk_idx_const);
+    auto axis0 = std::make_shared<Constant>(element::i64, Shape{},
+                                            std::vector<int64_t>{0});
+    auto result = std::make_shared<Gather>(vocab_const, safe_ids, axis0);
+
+    set_node_name(node_name, result);
+    return {result->output(0)};
+}
+
+ov::OutputVector
+translate_onnx_contrib_string_join(const ov::frontend::NodeContext &node) {
+    auto node_name = node.get_name();
+    FRONT_END_GENERAL_CHECK(node.get_input_size() == 3,
+        "ai.onnx.contrib.StringJoin expects 3 inputs "
+        "(input, sep, axis)");
+
+    auto input_unpacked = pre_translate_string_tensor_input(node.get_input(0));
+    auto sep_unpacked = pre_translate_string_tensor_input(node.get_input(1));
+
+    // axis: ensure i64
+    auto axis_in = node.get_input(2);
+    ov::Output<ov::Node> axis_i64;
+    if (axis_in.get_element_type() == element::i64) {
+        axis_i64 = axis_in;
+    } else {
+        axis_i64 = std::make_shared<Convert>(axis_in, element::i64);
+    }
+
+    OutputVector args;
+    args.insert(args.end(), input_unpacked.begin(), input_unpacked.end());
+    args.insert(args.end(), sep_unpacked.begin(), sep_unpacked.end());
+    args.push_back(axis_i64);
+
+    auto join = std::make_shared<ContribStringJoin>(args);
+    auto packed = post_translate_string_tensor_output(join->outputs());
+    set_node_name(node_name, packed.get_node_shared_ptr());
+    return {packed};
+}
+
+ov::OutputVector
+translate_onnx_contrib_string_split(const ov::frontend::NodeContext &node) {
+    auto node_name = node.get_name();
+    FRONT_END_GENERAL_CHECK(node.get_input_size() == 3,
+        "ai.onnx.contrib.StringSplit expects 3 inputs "
+        "(input, delimiter, skip_empty)");
+
+    auto input_unpacked = pre_translate_string_tensor_input(node.get_input(0));
+    auto delim_unpacked = pre_translate_string_tensor_input(node.get_input(1));
+
+    auto skip_in = node.get_input(2);
+    ov::Output<ov::Node> skip_bool;
+    if (skip_in.get_element_type() == element::boolean) {
+        skip_bool = skip_in;
+    } else {
+        skip_bool = std::make_shared<Convert>(skip_in, element::boolean);
+    }
+
+    OutputVector args;
+    args.insert(args.end(), input_unpacked.begin(), input_unpacked.end());
+    args.insert(args.end(), delim_unpacked.begin(), delim_unpacked.end());
+    args.push_back(skip_bool);
+
+    auto split = std::make_shared<ContribStringSplit>(args);
+    auto indices = split->output(0);
+    auto values_packed = post_translate_string_tensor_output(
+        OutputVector{split->output(1), split->output(2), split->output(3)});
+    auto dense_shape = split->output(4);
+
+    indices.add_names({node_name + ":0"});
+    values_packed.add_names({node_name + ":1"});
+    dense_shape.add_names({node_name + ":2"});
+
+    return {indices, values_packed, dense_shape};
 }

--- a/src/onnx_translators.hpp
+++ b/src/onnx_translators.hpp
@@ -17,3 +17,18 @@ translate_onnx_tokenizer(const ov::frontend::NodeContext &node);
 
 ov::OutputVector
 translate_onnx_tfid_vectorizer(const ov::frontend::NodeContext &node);
+
+ov::OutputVector
+translate_onnx_contrib_sentencepiece_tokenizer(const ov::frontend::NodeContext &node);
+
+ov::OutputVector
+translate_onnx_contrib_sentencepiece_decoder(const ov::frontend::NodeContext &node);
+
+ov::OutputVector
+translate_onnx_contrib_vector_to_string(const ov::frontend::NodeContext &node);
+
+ov::OutputVector
+translate_onnx_contrib_string_join(const ov::frontend::NodeContext &node);
+
+ov::OutputVector
+translate_onnx_contrib_string_split(const ov::frontend::NodeContext &node);

--- a/src/ov_extension.cpp
+++ b/src/ov_extension.cpp
@@ -5,6 +5,7 @@
 #include <openvino/frontend/onnx/extension/conversion.hpp>
 #include <openvino/frontend/tensorflow/extension/conversion.hpp>
 
+#include "contrib_string_ops.hpp"
 #include "tokenizer.hpp"
 #include "numeric_to_string.hpp"
 
@@ -16,7 +17,22 @@
       std::make_shared<ov::frontend::onnx::ConversionExtension>(               \
           "Tokenizer", "com.microsoft", translate_onnx_tokenizer),             \
       std::make_shared<ov::frontend::onnx::ConversionExtension>(               \
-          "TfIdfVectorizer", translate_onnx_tfid_vectorizer)
+          "TfIdfVectorizer", translate_onnx_tfid_vectorizer),                  \
+      std::make_shared<ov::frontend::onnx::ConversionExtension>(               \
+          "SentencepieceTokenizer", "ai.onnx.contrib",                         \
+          translate_onnx_contrib_sentencepiece_tokenizer),                     \
+      std::make_shared<ov::frontend::onnx::ConversionExtension>(               \
+          "SentencepieceDecoder", "ai.onnx.contrib",                           \
+          translate_onnx_contrib_sentencepiece_decoder),                       \
+      std::make_shared<ov::frontend::onnx::ConversionExtension>(               \
+          "VectorToString", "ai.onnx.contrib",                                 \
+          translate_onnx_contrib_vector_to_string),                            \
+      std::make_shared<ov::frontend::onnx::ConversionExtension>(               \
+          "StringJoin", "ai.onnx.contrib",                                     \
+          translate_onnx_contrib_string_join),                                 \
+      std::make_shared<ov::frontend::onnx::ConversionExtension>(               \
+          "StringSplit", "ai.onnx.contrib",                                    \
+          translate_onnx_contrib_string_split)
 
 #define OPENVINO_TOKENIZERS_TENSORFLOW_CONVERSION_EXTENSIONS                   \
   std::make_shared<ov::frontend::tensorflow::ConversionExtension>(             \
@@ -86,6 +102,8 @@ OPENVINO_CREATE_EXTENSIONS(
             std::make_shared<ov::OpExtension<CaseFold>>(),
             std::make_shared<ov::OpExtension<NormalizeUnicode>>(),
             std::make_shared<ov::OpExtension<UnigramTokenizer>>(),
+            std::make_shared<ov::OpExtension<ContribStringJoin>>(),
+            std::make_shared<ov::OpExtension<ContribStringSplit>>(),
             OPENVINO_TOKENIZERS_TENSORFLOW_CONVERSION_EXTENSIONS,
             OPENVINO_TOKENIZERS_ONNX_CONVERSION_EXTENSIONS
 }));

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import json
 import os
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 from io import StringIO
 from math import isclose
 from pathlib import Path
@@ -148,7 +148,10 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: pytest.ExitCode) -
     skipped = len(reporter.stats.get("skipped", []))
     pass_rate = 1 - session.testsfailed / (session.testscollected - skipped)
 
-    suffix = "transformers_v4" if version("transformers").startswith("4.") else ""
+    try:
+        suffix = "transformers_v4" if version("transformers").startswith("4.") else ""
+    except PackageNotFoundError:
+        suffix = ""
     previous = previous_rates.get(parent + suffix, 0)
     stats = reporter.stats
 

--- a/tests/onnx_contrib_test.py
+++ b/tests/onnx_contrib_test.py
@@ -1,0 +1,360 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Tests for the ai.onnx.contrib ONNX Frontend conversion extensions registered
+# by openvino_tokenizers:
+#   * SentencepieceTokenizer (6-input and optional 7-input "fairseq" variant)
+#   * SentencepieceDecoder
+#   * VectorToString
+#   * StringJoin
+#   * StringSplit
+#
+# A tiny SentencePiece model is trained on the fly so the SentencePiece tests
+# are self-contained and do not require any network access. The SentencePiece
+# library itself is used as the reference implementation; the string ops are
+# checked against hand-computed expected values.
+
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import openvino as ov
+import pytest
+
+# Importing the package patches openvino.Core to register the tokenizers
+# extension (including the ONNX Frontend conversion extensions under test).
+import openvino_tokenizers  # noqa: F401
+
+onnx = pytest.importorskip("onnx")
+spm = pytest.importorskip("sentencepiece")
+
+from onnx import TensorProto, helper  # noqa: E402
+
+
+_TRAIN_WORDS = (
+    "the quick brown fox jumps over a lazy dog hello world openvino "
+    "tokenizers sentencepiece model training corpus example text data "
+    "machine learning inference engine neural network compute graph"
+).split()
+
+
+@pytest.fixture(scope="module")
+def spm_model():
+    import random
+
+    tmp = Path(tempfile.mkdtemp())
+    corpus = tmp / "corpus.txt"
+    rng = random.Random(0)
+    with corpus.open("w") as f:
+        for _ in range(400):
+            n = rng.randint(3, 10)
+            f.write(" ".join(rng.choice(_TRAIN_WORDS) for _ in range(n)) + "\n")
+
+    prefix = tmp / "spm"
+    spm.SentencePieceTrainer.train(
+        input=str(corpus),
+        model_prefix=str(prefix),
+        vocab_size=48,
+        model_type="unigram",
+        character_coverage=1.0,
+        hard_vocab_limit=False,
+        bos_id=1,
+        eos_id=2,
+        unk_id=0,
+        pad_id=-1,
+    )
+    model_bytes = (prefix.with_suffix(".model")).read_bytes()
+    processor = spm.SentencePieceProcessor(model_file=str(prefix.with_suffix(".model")))
+    return model_bytes, processor
+
+
+def _scalar_const(name, value, dtype):
+    arr = np.asarray(value)
+    return helper.make_node(
+        "Constant",
+        [],
+        [name],
+        value=helper.make_tensor(name, dtype, [1], arr.ravel().tolist()),
+    )
+
+
+def _build_tokenizer_model(model_bytes, *, add_bos, add_eos, reverse, fairseq=None):
+    nodes = [
+        _scalar_const("nbest", [0], TensorProto.INT64),
+        _scalar_const("alpha", [0.0], TensorProto.FLOAT),
+        _scalar_const("add_bos", [add_bos], TensorProto.BOOL),
+        _scalar_const("add_eos", [add_eos], TensorProto.BOOL),
+        _scalar_const("reverse", [reverse], TensorProto.BOOL),
+    ]
+    tok_inputs = ["text", "nbest", "alpha", "add_bos", "add_eos", "reverse"]
+    if fairseq is not None:
+        nodes.append(_scalar_const("fairseq", [fairseq], TensorProto.BOOL))
+        tok_inputs.append("fairseq")
+    nodes.append(
+        helper.make_node(
+            "SentencepieceTokenizer",
+            tok_inputs,
+            ["tokens", "row_splits"],
+            domain="ai.onnx.contrib",
+            model=model_bytes,
+        )
+    )
+    graph = helper.make_graph(
+        nodes,
+        "tokenizer",
+        [helper.make_tensor_value_info("text", TensorProto.STRING, [None])],
+        [
+            helper.make_tensor_value_info("tokens", TensorProto.INT32, [None]),
+            helper.make_tensor_value_info("row_splits", TensorProto.INT64, [None]),
+        ],
+    )
+    return helper.make_model(
+        graph,
+        opset_imports=[helper.make_opsetid("", 17), helper.make_opsetid("ai.onnx.contrib", 1)],
+    )
+
+
+def _build_decoder_model(model_bytes, *, fairseq=False):
+    nodes = [
+        _scalar_const("fairseq", [fairseq], TensorProto.BOOL),
+        helper.make_node(
+            "SentencepieceDecoder",
+            ["ids", "fairseq"],
+            ["text"],
+            domain="ai.onnx.contrib",
+            model=model_bytes,
+        ),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        "decoder",
+        [helper.make_tensor_value_info("ids", TensorProto.INT64, [None, None])],
+        [helper.make_tensor_value_info("text", TensorProto.STRING, [None])],
+    )
+    return helper.make_model(
+        graph,
+        opset_imports=[helper.make_opsetid("", 17), helper.make_opsetid("ai.onnx.contrib", 1)],
+    )
+
+
+def _build_vector_to_string_model(map_text, unk):
+    node = helper.make_node(
+        "VectorToString",
+        ["ids"],
+        ["text"],
+        domain="ai.onnx.contrib",
+        map=map_text,
+        unk=unk,
+    )
+    graph = helper.make_graph(
+        [node],
+        "vector_to_string",
+        [helper.make_tensor_value_info("ids", TensorProto.INT64, [None])],
+        [helper.make_tensor_value_info("text", TensorProto.STRING, [None])],
+    )
+    return helper.make_model(
+        graph,
+        opset_imports=[helper.make_opsetid("", 17), helper.make_opsetid("ai.onnx.contrib", 1)],
+    )
+
+
+def _build_string_join_model():
+    node = helper.make_node(
+        "StringJoin", ["inp", "sep", "axis"], ["joined"], domain="ai.onnx.contrib"
+    )
+    graph = helper.make_graph(
+        [node],
+        "string_join",
+        [
+            helper.make_tensor_value_info("inp", TensorProto.STRING, [None]),
+            helper.make_tensor_value_info("sep", TensorProto.STRING, []),
+            helper.make_tensor_value_info("axis", TensorProto.INT64, []),
+        ],
+        [helper.make_tensor_value_info("joined", TensorProto.STRING, [None])],
+    )
+    return helper.make_model(
+        graph,
+        opset_imports=[helper.make_opsetid("", 17), helper.make_opsetid("ai.onnx.contrib", 1)],
+    )
+
+
+def _build_string_split_model():
+    node = helper.make_node(
+        "StringSplit",
+        ["inp", "delim", "skip"],
+        ["indices", "values", "shape"],
+        domain="ai.onnx.contrib",
+    )
+    graph = helper.make_graph(
+        [node],
+        "string_split",
+        [
+            helper.make_tensor_value_info("inp", TensorProto.STRING, [None]),
+            helper.make_tensor_value_info("delim", TensorProto.STRING, []),
+            helper.make_tensor_value_info("skip", TensorProto.BOOL, []),
+        ],
+        [
+            helper.make_tensor_value_info("indices", TensorProto.INT64, [None, None]),
+            helper.make_tensor_value_info("values", TensorProto.STRING, [None]),
+            helper.make_tensor_value_info("shape", TensorProto.INT64, [None]),
+        ],
+    )
+    return helper.make_model(
+        graph,
+        opset_imports=[helper.make_opsetid("", 17), helper.make_opsetid("ai.onnx.contrib", 1)],
+    )
+
+
+def _save(model, tmp_path, name):
+    path = tmp_path / name
+    onnx.save(model, str(path))
+    return str(path)
+
+
+def _run(onnx_path, feed):
+    core = ov.Core()
+    compiled = core.compile_model(core.read_model(onnx_path), "CPU")
+    request = compiled.create_infer_request()
+    for port in compiled.inputs:
+        request.set_tensor(port, feed[port.get_any_name()])
+    request.infer()
+    return [request.get_output_tensor(i) for i in range(len(compiled.outputs))]
+
+
+TEST_STRINGS = ["Hello world.", "openvino tokenizers", "the quick brown fox"]
+
+
+@pytest.mark.parametrize("text", TEST_STRINGS)
+@pytest.mark.parametrize(
+    "add_bos, add_eos, reverse",
+    [
+        (False, False, False),
+        (True, False, False),
+        (False, True, False),
+        (True, True, False),
+        (False, False, True),
+    ],
+)
+def test_sentencepiece_tokenizer(spm_model, tmp_path, text, add_bos, add_eos, reverse):
+    model_bytes, processor = spm_model
+    onnx_path = _save(
+        _build_tokenizer_model(model_bytes, add_bos=add_bos, add_eos=add_eos, reverse=reverse),
+        tmp_path,
+        "tok.onnx",
+    )
+
+    outputs = _run(onnx_path, {"text": ov.Tensor(np.array([text], dtype=str))})
+    tokens = outputs[0].data.tolist()
+
+    expected = processor.encode(text, add_bos=add_bos, add_eos=add_eos)
+    if reverse:
+        expected = expected[::-1]
+
+    assert tokens == expected
+    assert outputs[1].data.tolist() == [0, len(expected)]
+
+
+@pytest.mark.parametrize("text", TEST_STRINGS)
+def test_sentencepiece_tokenizer_fairseq_input(spm_model, tmp_path, text):
+    # The optional 7th input (fairseq) is accepted when set to False and must
+    # produce the same result as the 6-input form.
+    model_bytes, processor = spm_model
+    onnx_path = _save(
+        _build_tokenizer_model(
+            model_bytes, add_bos=True, add_eos=True, reverse=False, fairseq=False
+        ),
+        tmp_path,
+        "tok7.onnx",
+    )
+
+    outputs = _run(onnx_path, {"text": ov.Tensor(np.array([text], dtype=str))})
+    assert outputs[0].data.tolist() == processor.encode(text, add_bos=True, add_eos=True)
+
+
+def test_sentencepiece_tokenizer_fairseq_true_unsupported(spm_model, tmp_path):
+    # fairseq-mode id remapping is not implemented by the underlying op, so
+    # conversion must fail fast rather than silently produce wrong results.
+    model_bytes, _ = spm_model
+    onnx_path = _save(
+        _build_tokenizer_model(
+            model_bytes, add_bos=True, add_eos=True, reverse=False, fairseq=True
+        ),
+        tmp_path,
+        "tok_fairseq.onnx",
+    )
+    with pytest.raises(Exception, match="fairseq"):
+        ov.Core().read_model(onnx_path)
+
+
+@pytest.mark.parametrize("text", TEST_STRINGS)
+def test_sentencepiece_decoder(spm_model, tmp_path, text):
+    model_bytes, processor = spm_model
+    ids = processor.encode(text, add_bos=True, add_eos=True)
+    onnx_path = _save(_build_decoder_model(model_bytes), tmp_path, "dec.onnx")
+
+    outputs = _run(onnx_path, {"ids": ov.Tensor(np.array([ids], dtype=np.int64))})
+    decoded = outputs[0].str_data[0]
+
+    assert decoded == processor.decode(ids)
+
+
+def test_sentencepiece_decoder_fairseq_true_unsupported(spm_model, tmp_path):
+    model_bytes, _ = spm_model
+    onnx_path = _save(_build_decoder_model(model_bytes, fairseq=True), tmp_path, "dec_fairseq.onnx")
+    with pytest.raises(Exception, match="fairseq"):
+        ov.Core().read_model(onnx_path)
+
+
+def test_vector_to_string(tmp_path):
+    # id -> string lookup; out-of-range ids map to the `unk` token.
+    vocab = ["a", "b", "c", "hello", "world"]
+    map_text = "\n".join(f"{tok}\t{idx}" for idx, tok in enumerate(vocab))
+    onnx_path = _save(_build_vector_to_string_model(map_text, "<unk>"), tmp_path, "v2s.onnx")
+
+    ids = [3, 4, 0, 99, -1]
+    outputs = _run(onnx_path, {"ids": ov.Tensor(np.array(ids, dtype=np.int64))})
+
+    expected = [vocab[i] if 0 <= i < len(vocab) else "<unk>" for i in ids]
+    assert list(outputs[0].str_data) == expected
+
+
+def test_string_join(tmp_path):
+    onnx_path = _save(_build_string_join_model(), tmp_path, "join.onnx")
+    parts = ["hello", "world", "foo"]
+    outputs = _run(
+        onnx_path,
+        {
+            "inp": ov.Tensor(np.array(parts, dtype=str)),
+            "sep": ov.Tensor(np.array(" ", dtype=str)),
+            "axis": ov.Tensor(np.array(0, dtype=np.int64)),
+        },
+    )
+    assert outputs[0].str_data.ravel().tolist() == [" ".join(parts)]
+
+
+def test_string_split(tmp_path):
+    onnx_path = _save(_build_string_split_model(), tmp_path, "split.onnx")
+    strings = ["a b c", "d e"]
+    outputs = _run(
+        onnx_path,
+        {
+            "inp": ov.Tensor(np.array(strings, dtype=str)),
+            "delim": ov.Tensor(np.array(" ", dtype=str)),
+            "skip": ov.Tensor(np.array(True)),
+        },
+    )
+    indices, values, dense_shape = outputs
+
+    expected_values = []
+    expected_indices = []
+    max_cols = 0
+    for row, s in enumerate(strings):
+        cols = s.split(" ")
+        max_cols = max(max_cols, len(cols))
+        for col, token in enumerate(cols):
+            expected_indices.append([row, col])
+            expected_values.append(token)
+
+    assert list(values.str_data) == expected_values
+    assert indices.data.tolist() == expected_indices
+    assert dense_shape.data.tolist() == [len(strings), max_cols]

--- a/tests/onnx_contrib_test.py
+++ b/tests/onnx_contrib_test.py
@@ -14,8 +14,6 @@
 # library itself is used as the reference implementation; the string ops are
 # checked against hand-computed expected values.
 
-from pathlib import Path
-
 import numpy as np
 import openvino as ov
 import pytest

--- a/tests/onnx_contrib_test.py
+++ b/tests/onnx_contrib_test.py
@@ -14,7 +14,6 @@
 # library itself is used as the reference implementation; the string ops are
 # checked against hand-computed expected values.
 
-import tempfile
 from pathlib import Path
 
 import numpy as np
@@ -330,6 +329,41 @@ def test_string_join(tmp_path):
         },
     )
     assert outputs[0].str_data.ravel().tolist() == [" ".join(parts)]
+
+
+def test_string_join_empty_axis(tmp_path):
+    # Regression test: input shape [0, N] joined along axis 0 must produce N
+    # empty strings.  Previously the degenerate fast-path (shape_size <= 1)
+    # incorrectly triggered here, initialising only element 0 and leaving the
+    # rest of begins/ends uninitialized.
+    N = 3
+    node = helper.make_node(
+        "StringJoin", ["inp", "sep", "axis"], ["joined"], domain="ai.onnx.contrib"
+    )
+    graph = helper.make_graph(
+        [node],
+        "string_join_2d",
+        [
+            helper.make_tensor_value_info("inp", TensorProto.STRING, [None, None]),
+            helper.make_tensor_value_info("sep", TensorProto.STRING, []),
+            helper.make_tensor_value_info("axis", TensorProto.INT64, []),
+        ],
+        [helper.make_tensor_value_info("joined", TensorProto.STRING, [None])],
+    )
+    model = helper.make_model(
+        graph,
+        opset_imports=[helper.make_opsetid("", 17), helper.make_opsetid("ai.onnx.contrib", 1)],
+    )
+    onnx_path = _save(model, tmp_path, "join_empty_axis.onnx")
+    outputs = _run(
+        onnx_path,
+        {
+            "inp": ov.Tensor(np.empty((0, N), dtype=str)),
+            "sep": ov.Tensor(np.array("-", dtype=str)),
+            "axis": ov.Tensor(np.array(0, dtype=np.int64)),
+        },
+    )
+    assert outputs[0].str_data.ravel().tolist() == [""] * N
 
 
 def test_string_split(tmp_path):

--- a/tests/onnx_contrib_test.py
+++ b/tests/onnx_contrib_test.py
@@ -39,10 +39,10 @@ _TRAIN_WORDS = (
 
 
 @pytest.fixture(scope="module")
-def spm_model():
+def spm_model(tmp_path_factory):
     import random
 
-    tmp = Path(tempfile.mkdtemp())
+    tmp = tmp_path_factory.mktemp("spm")
     corpus = tmp / "corpus.txt"
     rng = random.Random(0)
     with corpus.open("w") as f:

--- a/tests/onnx_contrib_test.py
+++ b/tests/onnx_contrib_test.py
@@ -335,18 +335,23 @@ def test_string_join_empty_axis(tmp_path):
     # incorrectly triggered here, initialising only element 0 and leaving the
     # rest of begins/ends uninitialized.
     N = 3
+    # Embed axis=0 as an ONNX graph initializer (constant) so that OpenVINO
+    # creates a Constant node for it.  This lets validate_and_infer_types read
+    # the axis value and produce a static output shape, which the CPU plugin
+    # requires.
     node = helper.make_node(
         "StringJoin", ["inp", "sep", "axis"], ["joined"], domain="ai.onnx.contrib"
     )
+    axis_init = helper.make_tensor("axis", TensorProto.INT64, [], [0])
     graph = helper.make_graph(
         [node],
         "string_join_2d",
         [
-            helper.make_tensor_value_info("inp", TensorProto.STRING, [None, None]),
+            helper.make_tensor_value_info("inp", TensorProto.STRING, [0, N]),
             helper.make_tensor_value_info("sep", TensorProto.STRING, []),
-            helper.make_tensor_value_info("axis", TensorProto.INT64, []),
         ],
         [helper.make_tensor_value_info("joined", TensorProto.STRING, [None])],
+        initializer=[axis_init],
     )
     model = helper.make_model(
         graph,
@@ -358,7 +363,6 @@ def test_string_join_empty_axis(tmp_path):
         {
             "inp": ov.Tensor(np.empty((0, N), dtype=str)),
             "sep": ov.Tensor(np.array("-", dtype=str)),
-            "axis": ov.Tensor(np.array(0, dtype=np.int64)),
         },
     )
     assert outputs[0].str_data.ravel().tolist() == [""] * N

--- a/tests/onnx_contrib_test.py
+++ b/tests/onnx_contrib_test.py
@@ -358,3 +358,26 @@ def test_string_split(tmp_path):
     assert list(values.str_data) == expected_values
     assert indices.data.tolist() == expected_indices
     assert dense_shape.data.tolist() == [len(strings), max_cols]
+
+
+def test_string_split_skip_empty_preserves_original_positions(tmp_path):
+    # When skip_empty=True and consecutive delimiters produce empty tokens,
+    # the sparse COO indices must reflect the original (pre-skip) slot positions,
+    # not compressed filtered positions. dense_shape last dim must also be the
+    # max original token count (3 here), not the filtered count (2).
+    onnx_path = _save(_build_string_split_model(), tmp_path, "split_skip.onnx")
+    # "a  b" split on " " → ["a", "", "b"]; skip_empty drops ""; original positions 0, 2
+    strings = ["a  b", "x"]
+    outputs = _run(
+        onnx_path,
+        {
+            "inp": ov.Tensor(np.array(strings, dtype=str)),
+            "delim": ov.Tensor(np.array(" ", dtype=str)),
+            "skip": ov.Tensor(np.array(True)),
+        },
+    )
+    indices, values, dense_shape = outputs
+
+    assert list(values.str_data) == ["a", "b", "x"]
+    assert indices.data.tolist() == [[0, 0], [0, 2], [1, 0]]
+    assert dense_shape.data.tolist() == [2, 3]


### PR DESCRIPTION
### Details
- Adds ONNX Frontend conversion extensions for five ai.onnx.contrib operators emitted by onnxruntime_extensions, enabling read_model on ONNX models that embed SentencePiece tokenization and string post-processing (e.g. seq2seq pipelines exported with ORT extensions):

  - SentencepieceTokenizer — accepts both the 6-input form and the optional 7-input fairseq variant (validated to be false; fairseq-   style id remapping is unsupported and fails fast).
  - SentencepieceDecoder — maps token ids back to strings via SentencepieceDetokenizer (fairseq likewise validated false).
  - VectorToString — id→string lookup with unk fallback for out-of-range ids.
  - StringJoin — joins string elements along an axis with a separator.
  - StringSplit — splits strings by a delimiter into a sparse (indices, values, dense_shape) representation.
- All ops are registered as ConversionExtensions in ov_extension.cpp and resolve automatically once the tokenizers extension is loaded.