### PR TITLE
[ONNX FE] SentencepieceDetokenizer: tolerate dynamic-rank token-ids input

### DIFF
--- a/src/sentence_piece.cpp
+++ b/src/sentence_piece.cpp
@@ -375,9 +375,13 @@ SentencepieceDetokenizer::SentencepieceDetokenizer(const OutputVector& args, con
 void SentencepieceDetokenizer::validate_and_infer_types() {
     OPENVINO_ASSERT(get_input_size() == 2, "SentencepieceDetokenizer expects two inputs: sp model and token ids");
     OPENVINO_ASSERT(get_input_element_type(0) == element::u8, "SentencepieceDetokenizer accepts sp model as the first input and it should be of type u8 tensor");
-    OPENVINO_ASSERT(get_input_partial_shape(1).size() == 2, "SentencepieceDetokenizer expects 2D tensor as second input");
 
-    auto batch_size = PartialShape({get_input_partial_shape(1)[0]});
+    // Token-ids rank may be dynamic at translation time; defer the 2D check.
+    const auto& ids_shape = get_input_partial_shape(1);
+    OPENVINO_ASSERT(ids_shape.rank().is_dynamic() || ids_shape.size() == 2,
+                    "SentencepieceDetokenizer expects 2D tensor as second input");
+
+    auto batch_size = ids_shape.rank().is_static() ? PartialShape({ids_shape[0]}) : PartialShape{Dimension()};
     set_string_output(this, 0, batch_size);
 }
 
@@ -454,9 +458,13 @@ SentencepieceStreamDetokenizer::SentencepieceStreamDetokenizer(const OutputVecto
 void SentencepieceStreamDetokenizer::validate_and_infer_types() {
     OPENVINO_ASSERT(get_input_size() == 2, "SentencepieceDetokenizer expects two inputs: sp model and token ids");
     OPENVINO_ASSERT(get_input_element_type(0) == element::u8, "SentencepieceDetokenizer accepts sp model as the first input and it should be of type u8 tensor");
-    OPENVINO_ASSERT(get_input_partial_shape(1).size() == 2, "SentencepieceDetokenizer expects 2D tensor as second input");
 
-    auto batch_size = PartialShape({get_input_partial_shape(1)[0]});
+    // Token-ids rank may be dynamic at translation time; defer the 2D check.
+    const auto& ids_shape = get_input_partial_shape(1);
+    OPENVINO_ASSERT(ids_shape.rank().is_dynamic() || ids_shape.size() == 2,
+                    "SentencepieceDetokenizer expects 2D tensor as second input");
+
+    auto batch_size = ids_shape.rank().is_static() ? PartialShape({ids_shape[0]}) : PartialShape{Dimension()};
     set_string_output(this, 0, batch_size);
 }
 

--- a/src/sentence_piece.cpp
+++ b/src/sentence_piece.cpp
@@ -378,7 +378,7 @@ void SentencepieceDetokenizer::validate_and_infer_types() {
 
     // Token-ids rank may be dynamic at translation time; defer the 2D check.
     const auto& ids_shape = get_input_partial_shape(1);
-    OPENVINO_ASSERT(ids_shape.rank().is_dynamic() || ids_shape.size() == 2,
+    OPENVINO_ASSERT(ids_shape.rank().is_dynamic() || ids_shape.rank().get_length() == 2,
                     "SentencepieceDetokenizer expects 2D tensor as second input");
 
     auto batch_size = ids_shape.rank().is_static() ? PartialShape({ids_shape[0]}) : PartialShape{Dimension()};
@@ -456,13 +456,13 @@ SentencepieceStreamDetokenizer::SentencepieceStreamDetokenizer(const OutputVecto
 }
 
 void SentencepieceStreamDetokenizer::validate_and_infer_types() {
-    OPENVINO_ASSERT(get_input_size() == 2, "SentencepieceDetokenizer expects two inputs: sp model and token ids");
-    OPENVINO_ASSERT(get_input_element_type(0) == element::u8, "SentencepieceDetokenizer accepts sp model as the first input and it should be of type u8 tensor");
+    OPENVINO_ASSERT(get_input_size() == 2, "SentencepieceStreamDetokenizer expects two inputs: sp model and token ids");
+    OPENVINO_ASSERT(get_input_element_type(0) == element::u8, "SentencepieceStreamDetokenizer accepts sp model as the first input and it should be of type u8 tensor");
 
     // Token-ids rank may be dynamic at translation time; defer the 2D check.
     const auto& ids_shape = get_input_partial_shape(1);
-    OPENVINO_ASSERT(ids_shape.rank().is_dynamic() || ids_shape.size() == 2,
-                    "SentencepieceDetokenizer expects 2D tensor as second input");
+    OPENVINO_ASSERT(ids_shape.rank().is_dynamic() || ids_shape.rank().get_length() == 2,
+                    "SentencepieceStreamDetokenizer expects 2D tensor as second input");
 
     auto batch_size = ids_shape.rank().is_static() ? PartialShape({ids_shape[0]}) : PartialShape{Dimension()};
     set_string_output(this, 0, batch_size);

--- a/tests/onnx_contrib_test.py
+++ b/tests/onnx_contrib_test.py
@@ -134,6 +134,31 @@ def _build_decoder_model(model_bytes, *, fairseq=False):
     )
 
 
+def _build_decoder_model_dynamic_rank(model_bytes):
+    # Like _build_decoder_model, but token-ids is declared with unknown rank
+    # (shape=None), mirroring a decoder fed from a not-yet-inferred Loop output.
+    nodes = [
+        _scalar_const("fairseq", [False], TensorProto.BOOL),
+        helper.make_node(
+            "SentencepieceDecoder",
+            ["ids", "fairseq"],
+            ["text"],
+            domain="ai.onnx.contrib",
+            model=model_bytes,
+        ),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        "decoder_dyn_rank",
+        [helper.make_tensor_value_info("ids", TensorProto.INT64, None)],
+        [helper.make_tensor_value_info("text", TensorProto.STRING, [None])],
+    )
+    return helper.make_model(
+        graph,
+        opset_imports=[helper.make_opsetid("", 17), helper.make_opsetid("ai.onnx.contrib", 1)],
+    )
+
+
 def _build_vector_to_string_model(map_text, unk):
     node = helper.make_node(
         "VectorToString",
@@ -293,6 +318,16 @@ def test_sentencepiece_decoder(spm_model, tmp_path, text):
     decoded = outputs[0].str_data[0]
 
     assert decoded == processor.decode(ids)
+
+
+def test_sentencepiece_decoder_dynamic_rank_input(spm_model, tmp_path):
+    # Regression: an unknown-rank token-ids input must not throw during
+    # conversion (the 2D check is deferred until the rank is known).
+    model_bytes, _ = spm_model
+    onnx_path = _save(_build_decoder_model_dynamic_rank(model_bytes), tmp_path, "dec_dyn_rank.onnx")
+
+    model = ov.Core().read_model(onnx_path)  # must not raise
+    assert model.output(0).get_element_type() == ov.Type.string
 
 
 def test_sentencepiece_decoder_fairseq_true_unsupported(spm_model, tmp_path):


### PR DESCRIPTION
### Summary
 - SentencepieceDetokenizer::validate_and_infer_types (and the stream variant) called PartialShape::size() on the token-ids input, which throws rank().is_static() when the rank is dynamic. This aborts ONNX conversion of models whose SentencepieceDecoder is fed from a value whose rank isn't inferred yet at translation time — e.g. a decoder Loop output.

### Change
 - Only enforce the 2D requirement once the rank is known; derive batch_size dynamically otherwise. Applied to both SentencepieceDetokenizer and SentencepieceStreamDetokenizer.
 
### Tickets:
 - CVS-187784