### PR TITLE
Optimizes BPE Tokenization

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -349,11 +349,17 @@ jobs:
       - name: Install OpenVINO tokenizers wheel
         run: uv pip install --no-deps ${{ steps.tokenizers_wheel.outputs.wheel_path }}
 
-      - name: Tokenizers regression tests (using openvino python wheels)
-        run: uv run --no-sync pytest tests -n auto
+      - name: Tokenizers pass-rate tests (using openvino python wheels)
+        run: uv run --no-sync pytest tests/tokenizers_test.py -n auto
 
-      - name: Tokenizers regression tests (with transformers v4)
-        run: uv run --no-sync --with "transformers[sentencepiece]>=4.0.0,<5" pytest tests -n auto
+      - name: Tokenizer functional tests (using openvino python wheels)
+        run: uv run --no-sync pytest tests --ignore=tests/tokenizers_test.py -n auto
+
+      - name: Tokenizers pass-rate tests (with transformers v4)
+        run: uv run --no-sync --with "transformers[sentencepiece]>=4.0.0,<5" pytest tests/tokenizers_test.py -n auto
+
+      - name: Tokenizer functional tests (with transformers v4)
+        run: uv run --no-sync --with "transformers[sentencepiece]>=4.0.0,<5" pytest tests --ignore=tests/tokenizers_test.py -n auto
         
   openvino_tf_tests:
     name: OpenVINO TensorFlow tests

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -383,8 +383,11 @@ jobs:
       - name: Install OpenVINO tokenizers wheel
         run: uv pip install --no-deps ${{ steps.tokenizers_wheel.outputs.wheel_path }}
 
-      - name: Tokenizers regression tests (using openvino python wheel)
+      - name: Tokenizers pass-rate tests (using openvino python wheel)
         run: uv run --no-sync pytest tests/tokenizers_test.py -n auto
+
+      - name: Tokenizer functional tests (using openvino python wheel)
+        run: uv run --no-sync pytest tests --ignore=tests/tokenizers_test.py -n auto
 
   Overall_Status:
     name: ci/gha_overall_status_macos

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -436,10 +436,15 @@ jobs:
       - name: Install OpenVINO tokenizers wheel
         run: uv pip install --no-deps ${{ steps.tokenizers_wheel.outputs.wheel_path }}
 
-      - name: Tokenizers regression tests (using openvino python modules)
+      - name: Tokenizers pass-rate tests (using openvino python modules)
         run: |
           . "${{ env.INSTALL_DIR }}/setupvars.ps1"
-          uv run --no-sync pytest tests -n auto
+          uv run --no-sync pytest tests/tokenizers_test.py -n auto
+
+      - name: Tokenizer functional tests (using openvino python modules)
+        run: |
+          . "${{ env.INSTALL_DIR }}/setupvars.ps1"
+          uv run --no-sync pytest tests --ignore=tests/tokenizers_test.py -n auto
 
   openvino_onnx_contrib_tests:
     name: OpenVINO ONNX contrib tests

--- a/src/bpe_result_cache.hpp
+++ b/src/bpe_result_cache.hpp
@@ -84,7 +84,7 @@ public:
             return ValueView{};
         }
 
-        const  fingFingerprinterprint = stored_fingerprint(hash_value);
+        const Fingerprint fingerprint = stored_fingerprint(hash_value);
         size_t slot_idx = static_cast<size_t>(hash_value) & m_mask;
         for (size_t probes = 0; probes < m_slots.size(); ++probes) {
             const Slot& slot = m_slots[slot_idx];

--- a/src/bpe_result_cache.hpp
+++ b/src/bpe_result_cache.hpp
@@ -1,0 +1,133 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+class BPEResultCache {
+public:
+    enum class InsertResult {
+        INSERTED,
+        EXISTING,
+        SATURATED,
+    };
+
+    explicit BPEResultCache(size_t max_entries = 0) : m_max_entries(max_entries) {
+        if (max_entries == 0) {
+            return;
+        }
+
+        size_t slot_count = 1;
+        while (max_entries > max_entries_for_slots(slot_count)) {
+            if (slot_count > std::numeric_limits<size_t>::max() / 2) {
+                throw std::length_error("BPE result cache capacity is too large");
+            }
+            slot_count *= 2;
+        }
+        m_slots.resize(slot_count);
+        m_mask = slot_count - 1;
+    }
+
+    static uint64_t hash(std::string_view key) {
+        uint64_t value = 14695981039346656037ULL;
+        for (const unsigned char byte : key) {
+            value ^= byte;
+            value *= 1099511628211ULL;
+        }
+        return value;
+    }
+
+    const std::vector<int32_t>* find(std::string_view key, uint64_t hash_value) const {
+        if (m_slots.empty()) {
+            return nullptr;
+        }
+
+        const uint64_t fingerprint = stored_fingerprint(hash_value);
+        size_t slot_idx = static_cast<size_t>(hash_value) & m_mask;
+        for (size_t probes = 0; probes < m_slots.size(); ++probes) {
+            const Slot& slot = m_slots[slot_idx];
+            if (slot.fingerprint == 0) {
+                return nullptr;
+            }
+            if (slot.fingerprint == fingerprint && keys_equal(slot.key, key)) {
+                return &slot.value;
+            }
+            slot_idx = (slot_idx + 1) & m_mask;
+        }
+        return nullptr;
+    }
+
+    const std::vector<int32_t>* find(std::string_view key) const {
+        return find(key, hash(key));
+    }
+
+    template <typename Iterator>
+    InsertResult insert(std::string_view key, uint64_t hash_value, Iterator value_begin, Iterator value_end) {
+        if (m_size >= m_max_entries || m_slots.empty()) {
+            return InsertResult::SATURATED;
+        }
+
+        const uint64_t fingerprint = stored_fingerprint(hash_value);
+        size_t slot_idx = static_cast<size_t>(hash_value) & m_mask;
+        for (size_t probes = 0; probes < m_slots.size(); ++probes) {
+            Slot& slot = m_slots[slot_idx];
+            if (slot.fingerprint == 0) {
+                std::string owned_key(key);
+                std::vector<int32_t> owned_value(value_begin, value_end);
+                slot.key = std::move(owned_key);
+                slot.value = std::move(owned_value);
+                slot.fingerprint = fingerprint;
+                ++m_size;
+                return InsertResult::INSERTED;
+            }
+            if (slot.fingerprint == fingerprint && keys_equal(slot.key, key)) {
+                return InsertResult::EXISTING;
+            }
+            slot_idx = (slot_idx + 1) & m_mask;
+        }
+        return InsertResult::SATURATED;
+    }
+
+    size_t size() const {
+        return m_size;
+    }
+
+    size_t slot_count() const {
+        return m_slots.size();
+    }
+
+private:
+    struct Slot {
+        uint64_t fingerprint = 0;
+        std::string key;
+        std::vector<int32_t> value;
+    };
+
+    static size_t max_entries_for_slots(size_t slot_count) {
+        return (slot_count / 10) * 7 + ((slot_count % 10) * 7) / 10;
+    }
+
+    static uint64_t stored_fingerprint(uint64_t hash_value) {
+        return hash_value == std::numeric_limits<uint64_t>::max() ? hash_value : hash_value + 1;
+    }
+
+    static bool keys_equal(const std::string& stored, std::string_view candidate) {
+        return stored.size() == candidate.size() &&
+               std::equal(stored.begin(), stored.end(), candidate.begin());
+    }
+
+    std::vector<Slot> m_slots;
+    size_t m_mask = 0;
+    size_t m_size = 0;
+    size_t m_max_entries = 0;
+};

--- a/src/bpe_result_cache.hpp
+++ b/src/bpe_result_cache.hpp
@@ -7,19 +7,47 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
 #include <limits>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
 
+// Fingerprint matches are confirmed by a full key comparison, so truncation
+// affects collision frequency but not correctness.
+#ifndef BPE_CACHE_FINGERPRINT_BITS
+#    define BPE_CACHE_FINGERPRINT_BITS 32
+#endif
+
+// Cache from a pretoken to its BPE token-id sequence.
+// Values of up to four token ids are stored inline; longer values use stable,
+// append-only arena storage.
 class BPEResultCache {
 public:
     enum class InsertResult {
         INSERTED,
         EXISTING,
         SATURATED,
+    };
+
+    // Valid while the caller holds the lock used for lookup. An empty stored
+    // value has non-null data and size zero.
+    struct ValueView {
+        const int32_t* data = nullptr;
+        size_t size = 0;
+
+        const int32_t* begin() const {
+            return data;
+        }
+        const int32_t* end() const {
+            return data + size;
+        }
+        bool found() const {
+            return data != nullptr;
+        }
     };
 
     explicit BPEResultCache(size_t max_entries = 0) : m_max_entries(max_entries) {
@@ -38,6 +66,10 @@ public:
         m_mask = slot_count - 1;
     }
 
+    // Slots contain pointers into this cache's spill arena.
+    BPEResultCache(const BPEResultCache&) = delete;
+    BPEResultCache& operator=(const BPEResultCache&) = delete;
+
     static uint64_t hash(std::string_view key) {
         uint64_t value = 14695981039346656037ULL;
         for (const unsigned char byte : key) {
@@ -47,27 +79,27 @@ public:
         return value;
     }
 
-    const std::vector<int32_t>* find(std::string_view key, uint64_t hash_value) const {
+    ValueView find(std::string_view key, uint64_t hash_value) const {
         if (m_slots.empty()) {
-            return nullptr;
+            return ValueView{};
         }
 
-        const uint64_t fingerprint = stored_fingerprint(hash_value);
+        const  fingFingerprinterprint = stored_fingerprint(hash_value);
         size_t slot_idx = static_cast<size_t>(hash_value) & m_mask;
         for (size_t probes = 0; probes < m_slots.size(); ++probes) {
             const Slot& slot = m_slots[slot_idx];
             if (slot.fingerprint == 0) {
-                return nullptr;
+                return ValueView{};
             }
             if (slot.fingerprint == fingerprint && keys_equal(slot.key, key)) {
-                return &slot.value;
+                return ValueView{slot.tokens(), slot.count};
             }
             slot_idx = (slot_idx + 1) & m_mask;
         }
-        return nullptr;
+        return ValueView{};
     }
 
-    const std::vector<int32_t>* find(std::string_view key) const {
+    ValueView find(std::string_view key) const {
         return find(key, hash(key));
     }
 
@@ -77,15 +109,28 @@ public:
             return InsertResult::SATURATED;
         }
 
-        const uint64_t fingerprint = stored_fingerprint(hash_value);
+        const Fingerprint fingerprint = stored_fingerprint(hash_value);
         size_t slot_idx = static_cast<size_t>(hash_value) & m_mask;
         for (size_t probes = 0; probes < m_slots.size(); ++probes) {
             Slot& slot = m_slots[slot_idx];
             if (slot.fingerprint == 0) {
+                const size_t value_size = static_cast<size_t>(std::distance(value_begin, value_end));
+                // Decline values that cannot be represented by the slot count.
+                if (value_size > std::numeric_limits<TokenCount>::max()) {
+                    return InsertResult::SATURATED;
+                }
+                // Keep the slot unoccupied until allocation and copying succeed.
                 std::string owned_key(key);
-                std::vector<int32_t> owned_value(value_begin, value_end);
+                int32_t* storage = nullptr;
+                if (value_size > INLINE_TOKENS) {
+                    storage = allocate_spill(value_size);
+                    slot.value.spill = storage;
+                } else {
+                    storage = slot.value.inline_tokens;
+                }
+                std::copy(value_begin, value_end, storage);
+                slot.count = static_cast<TokenCount>(value_size);
                 slot.key = std::move(owned_key);
-                slot.value = std::move(owned_value);
                 slot.fingerprint = fingerprint;
                 ++m_size;
                 return InsertResult::INSERTED;
@@ -107,18 +152,55 @@ public:
     }
 
 private:
+    static constexpr size_t INLINE_TOKENS = 4;
+
+#if BPE_CACHE_FINGERPRINT_BITS == 64
+    using Fingerprint = uint64_t;
+#elif BPE_CACHE_FINGERPRINT_BITS == 32
+    using Fingerprint = uint32_t;
+#else
+#    error "BPE_CACHE_FINGERPRINT_BITS must be 32 or 64"
+#endif
+    using TokenCount = uint32_t;
+
     struct Slot {
-        uint64_t fingerprint = 0;
+        Fingerprint fingerprint = 0;
+        TokenCount count = 0;
+        union Value {
+            int32_t inline_tokens[INLINE_TOKENS];
+            const int32_t* spill;
+        } value{};
         std::string key;
-        std::vector<int32_t> value;
+
+        const int32_t* tokens() const {
+            return count > INLINE_TOKENS ? value.spill : value.inline_tokens;
+        }
     };
+
+    // Pointees remain stable when the chunk list grows.
+    static constexpr size_t SPILL_CHUNK_TOKENS = 4096;
+
+    int32_t* allocate_spill(size_t value_size) {
+        if (m_spill_chunks.empty() || m_spill_used + value_size > m_spill_capacity) {
+            const size_t chunk_tokens = std::max(value_size, SPILL_CHUNK_TOKENS);
+            m_spill_chunks.push_back(std::make_unique<int32_t[]>(chunk_tokens));
+            m_spill_capacity = chunk_tokens;
+            m_spill_used = 0;
+        }
+        int32_t* storage = m_spill_chunks.back().get() + m_spill_used;
+        m_spill_used += value_size;
+        return storage;
+    }
 
     static size_t max_entries_for_slots(size_t slot_count) {
         return (slot_count / 10) * 7 + ((slot_count % 10) * 7) / 10;
     }
 
-    static uint64_t stored_fingerprint(uint64_t hash_value) {
-        return hash_value == std::numeric_limits<uint64_t>::max() ? hash_value : hash_value + 1;
+    // Reserve zero as the empty-slot sentinel.
+    static Fingerprint stored_fingerprint(uint64_t hash_value) {
+        const Fingerprint truncated = static_cast<Fingerprint>(hash_value);
+        return truncated == std::numeric_limits<Fingerprint>::max() ? truncated
+                                                                   : static_cast<Fingerprint>(truncated + 1);
     }
 
     static bool keys_equal(const std::string& stored, std::string_view candidate) {
@@ -127,6 +209,9 @@ private:
     }
 
     std::vector<Slot> m_slots;
+    std::vector<std::unique_ptr<int32_t[]>> m_spill_chunks;
+    size_t m_spill_used = 0;
+    size_t m_spill_capacity = 0;
     size_t m_mask = 0;
     size_t m_size = 0;
     size_t m_max_entries = 0;

--- a/src/bpe_tokenizer.cpp
+++ b/src/bpe_tokenizer.cpp
@@ -320,9 +320,9 @@ void BPETokenizerImpl::tokenize_into(std::string_view text, std::vector<int32_t>
 
     {
         std::shared_lock<std::shared_mutex> lock(m_mutex);
-        const auto* cached_result = m_cache.find(text, cache_hash);
-        if (cached_result != nullptr) {
-            out.insert(out.end(), cached_result->begin(), cached_result->end());
+        const auto cached_result = m_cache.find(text, cache_hash);
+        if (cached_result.found()) {
+            out.insert(out.end(), cached_result.begin(), cached_result.end());
             return;
         }
     }

--- a/src/bpe_tokenizer.cpp
+++ b/src/bpe_tokenizer.cpp
@@ -5,6 +5,8 @@
 #include "bpe_tokenizer.hpp"
 #include "openvino/opsets/opset13.hpp"
 #include "absl/strings/str_format.h"
+#include <array>
+#include <limits>
 #include <queue>
 using namespace ov;
 using namespace ov::opset13;
@@ -182,6 +184,127 @@ public:
     }
 };
 
+namespace {
+
+constexpr size_t SHORT_BPE_MAX_SYMBOLS = 32;
+constexpr size_t SHORT_BPE_MAX_NODES = 2 * SHORT_BPE_MAX_SYMBOLS - 1;
+constexpr int32_t NO_INDEX = -1;
+constexpr int32_t NO_RANK = std::numeric_limits<int32_t>::max();
+
+struct ShortBPESymbol {
+    int32_t id = -1;
+    int32_t prev = NO_INDEX;
+    int32_t next = NO_INDEX;
+    bool alive = false;
+};
+
+void merge_short_bpe(
+    const Merges& merges,
+    const std::vector<BPESymbol>& initial_symbols,
+    std::vector<int32_t>& out
+) {
+    const size_t initial_size = initial_symbols.size();
+    OPENVINO_ASSERT(initial_size <= SHORT_BPE_MAX_SYMBOLS);
+    if (initial_size == 0) {
+        return;
+    }
+
+    std::array<ShortBPESymbol, SHORT_BPE_MAX_NODES> symbols{};
+    std::array<int32_t, SHORT_BPE_MAX_NODES> ranks{};
+    std::array<int32_t, SHORT_BPE_MAX_NODES> merged_ids{};
+    std::array<int32_t, SHORT_BPE_MAX_NODES> sequence_numbers{};
+    ranks.fill(NO_RANK);
+    merged_ids.fill(-1);
+    sequence_numbers.fill(NO_RANK);
+
+    for (size_t idx = 0; idx < initial_size; ++idx) {
+        symbols[idx] = ShortBPESymbol{
+            initial_symbols[idx].id,
+            idx == 0 ? NO_INDEX : static_cast<int32_t>(idx - 1),
+            idx + 1 == initial_size ? NO_INDEX : static_cast<int32_t>(idx + 1),
+            true
+        };
+    }
+
+    auto set_candidate = [&](int32_t first, int32_t second, int32_t sequence_number) {
+        const MergeValue* merge = merges.find(symbols[first].id, symbols[second].id);
+        if (merge == nullptr) {
+            ranks[first] = NO_RANK;
+            merged_ids[first] = -1;
+            sequence_numbers[first] = NO_RANK;
+            return;
+        }
+        ranks[first] = merge->rank;
+        merged_ids[first] = merge->new_id;
+        sequence_numbers[first] = sequence_number;
+    };
+
+    int32_t sequence_number = 0;
+    for (size_t idx = 0; idx + 1 < initial_size; ++idx) {
+        set_candidate(static_cast<int32_t>(idx), static_cast<int32_t>(idx + 1), sequence_number++);
+    }
+
+    int32_t head = 0;
+    size_t node_count = initial_size;
+    size_t live_count = initial_size;
+    while (live_count >= 2) {
+        int32_t best = NO_INDEX;
+        for (size_t idx = 0; idx < node_count; ++idx) {
+            if (ranks[idx] == NO_RANK) {
+                continue;
+            }
+            if (best == NO_INDEX ||
+                ranks[idx] < ranks[best] ||
+                (ranks[idx] == ranks[best] && sequence_numbers[idx] < sequence_numbers[best])) {
+                best = static_cast<int32_t>(idx);
+            }
+        }
+        if (best == NO_INDEX) {
+            break;
+        }
+
+        const int32_t second = symbols[best].next;
+        OPENVINO_ASSERT(second != NO_INDEX && symbols[best].alive && symbols[second].alive);
+        const int32_t prev = symbols[best].prev;
+        const int32_t next = symbols[second].next;
+        const int32_t merged = static_cast<int32_t>(node_count++);
+        OPENVINO_ASSERT(node_count <= symbols.size());
+
+        symbols[merged] = ShortBPESymbol{merged_ids[best], prev, next, true};
+        symbols[best].alive = false;
+        symbols[second].alive = false;
+        ranks[best] = NO_RANK;
+        ranks[second] = NO_RANK;
+        sequence_numbers[best] = NO_RANK;
+        sequence_numbers[second] = NO_RANK;
+
+        if (prev != NO_INDEX) {
+            symbols[prev].next = merged;
+        } else {
+            head = merged;
+        }
+        if (next != NO_INDEX) {
+            symbols[next].prev = merged;
+        }
+
+        --live_count;
+        ++sequence_number;
+        if (prev != NO_INDEX) {
+            set_candidate(prev, merged, sequence_number);
+        }
+        if (next != NO_INDEX) {
+            set_candidate(merged, next, sequence_number);
+        }
+    }
+
+    out.reserve(out.size() + live_count);
+    for (int32_t idx = head; idx != NO_INDEX; idx = symbols[idx].next) {
+        out.push_back(symbols[idx].id);
+    }
+}
+
+}  // namespace
+
 std::vector<int32_t> BPETokenizerImpl::tokenize(std::string& text) {
     std::vector<int32_t> result;
     tokenize_into(std::string_view(text), result);
@@ -259,74 +382,78 @@ void BPETokenizerImpl::tokenize_into(std::string_view text, std::vector<int32_t>
     const size_t out_start = out.size();
     size_t live_count = symbols.size();
 
-    // Prepare priority queue to store pairs with their ranks.
-    scratch.queue_storage.clear();
-    scratch.queue_storage.reserve(symbols.size());
-    ReusableBPEQueue pq(std::move(scratch.queue_storage));
+    if (initial_num_tokens <= SHORT_BPE_MAX_SYMBOLS) {
+        merge_short_bpe(m_merges, symbols, out);
+    } else {
+        // Prepare priority queue to store pairs with their ranks.
+        scratch.queue_storage.clear();
+        scratch.queue_storage.reserve(symbols.size());
+        ReusableBPEQueue pq(std::move(scratch.queue_storage));
 
-    // replacement sequence number, is used in CompareRank.
-    // When merges have the same position prefer replaces which occured earlier.
-    int32_t i = 0;
+        // replacement sequence number, is used in CompareRank.
+        // When merges have the same position prefer replaces which occured earlier.
+        int32_t i = 0;
 
-    // Try to enqueue the pair (a, b) of adjacent symbol indices if it is a known merge.
-    auto try_push = [&](int32_t a, int32_t b) {
-        const MergeValue* merge = m_merges.find(symbols[a].id, symbols[b].id);
-        if (merge != nullptr) {
-            pq.emplace(merge->rank, merge->new_id, a, b, i);
+        // Try to enqueue the pair (a, b) of adjacent symbol indices if it is a known merge.
+        auto try_push = [&](int32_t a, int32_t b) {
+            const MergeValue* merge = m_merges.find(symbols[a].id, symbols[b].id);
+            if (merge != nullptr) {
+                pq.emplace(merge->rank, merge->new_id, a, b, i);
+            }
+        };
+
+        // Fill the priority queue with initial pairs. head tracks the index of the
+        // first live symbol; it moves when a merge consumes the current head.
+        int32_t head = symbols.empty() ? -1 : 0;
+        for (int32_t a = head; a != -1 && symbols[a].next != -1; a = symbols[a].next) {
+            try_push(a, symbols[a].next);
+            i++;
         }
-    };
 
-    // Fill the priority queue with initial pairs. head tracks the index of the
-    // first live symbol; it moves when a merge consumes the current head.
-    int32_t head = symbols.empty() ? -1 : 0;
-    for (int32_t a = head; a != -1 && symbols[a].next != -1; a = symbols[a].next) {
-        try_push(a, symbols[a].next);
-        i++;
+        while (!pq.empty() && live_count >= 2) {
+            auto [merge_idx, merged_id, first, second, position] = pq.top();
+            pq.pop();
+
+            // Skip stale entries: a merge always consumes (kills) its two operands,
+            // so two symbols that formed a pair stay adjacent while both are alive.
+            if (!symbols[first].alive || !symbols[second].alive || symbols[first].next != second) {
+                continue;
+            }
+
+            // Merge: append a new symbol that takes first's left neighbor and second's
+            // right neighbor, then mark the operands dead.
+            const int32_t prev = symbols[first].prev;
+            const int32_t next = symbols[second].next;
+            const int32_t merged = static_cast<int32_t>(symbols.size());
+            symbols.push_back(BPESymbol{merged_id, prev, next, true});
+            symbols[first].alive = false;
+            symbols[second].alive = false;
+            if (prev != -1) {
+                symbols[prev].next = merged;
+            } else {
+                head = merged;
+            }
+            if (next != -1) {
+                symbols[next].prev = merged;
+            }
+            live_count--;
+            i++;
+
+            // Enqueue the new pairs created on the left and right of the merged symbol.
+            if (prev != -1) {
+                try_push(prev, merged);
+            }
+            if (next != -1) {
+                try_push(merged, next);
+            }
+        }
+
+        for (int32_t idx = head; idx != -1; idx = symbols[idx].next) {
+            out.emplace_back(symbols[idx].id);
+        }
+        scratch.queue_storage = pq.release_storage();
+        scratch.queue_storage.clear();
     }
-
-    while (!pq.empty() && live_count >= 2) {
-        auto [merge_idx, merged_id, first, second, position] = pq.top();
-        pq.pop();
-
-        // Skip stale entries: a merge always consumes (kills) its two operands,
-        // so two symbols that formed a pair stay adjacent while both are alive.
-        if (!symbols[first].alive || !symbols[second].alive || symbols[first].next != second) {
-            continue;
-        }
-
-        // Merge: append a new symbol that takes first's left neighbor and second's
-        // right neighbor, then mark the operands dead.
-        const int32_t prev = symbols[first].prev;
-        const int32_t next = symbols[second].next;
-        const int32_t merged = static_cast<int32_t>(symbols.size());
-        symbols.push_back(BPESymbol{merged_id, prev, next, true});
-        symbols[first].alive = false;
-        symbols[second].alive = false;
-        if (prev != -1) {
-            symbols[prev].next = merged;
-        } else {
-            head = merged;
-        }
-        if (next != -1) {
-            symbols[next].prev = merged;
-        }
-        live_count--;
-        i++;
-
-        // Enqueue the new pairs created on the left and right of the merged symbol.
-        if (prev != -1) {
-            try_push(prev, merged);
-        }
-        if (next != -1) {
-            try_push(merged, next);
-        }
-    }
-
-    for (int32_t idx = head; idx != -1; idx = symbols[idx].next) {
-        out.emplace_back(symbols[idx].id);
-    }
-    scratch.queue_storage = pq.release_storage();
-    scratch.queue_storage.clear();
 
     {
         // Cache writes take an exclusive lock; lookups above take a shared lock.

--- a/src/bpe_tokenizer.cpp
+++ b/src/bpe_tokenizer.cpp
@@ -13,7 +13,6 @@ using namespace ov::opset13;
 
 #undef tokenizer
 
-
 void BPETokenizer::validate_and_infer_types() {
     auto input_size = get_input_size();
 
@@ -317,12 +316,13 @@ void BPETokenizerImpl::tokenize_into(std::string_view text, std::vector<int32_t>
 }
 
 void BPETokenizerImpl::tokenize_into(std::string_view text, std::vector<int32_t>& out, BPETokenizerScratch& scratch) {
-    std::string cache_key(text);
+    const uint64_t cache_hash = BPEResultCache::hash(text);
+
     {
         std::shared_lock<std::shared_mutex> lock(m_mutex);
-        const auto it = m_cache.find(cache_key);
-        if (it != m_cache.end()) {
-            out.insert(out.end(), it->second.begin(), it->second.end());
+        const auto* cached_result = m_cache.find(text, cache_hash);
+        if (cached_result != nullptr) {
+            out.insert(out.end(), cached_result->begin(), cached_result->end());
             return;
         }
     }
@@ -372,7 +372,8 @@ void BPETokenizerImpl::tokenize_into(std::string_view text, std::vector<int32_t>
 
         if (fallback_id != -1) {
             append_symbol(fallback_id);
-        } else if (m_unk_token_id != -1 && (!m_fuse_unk || symbols.empty() || symbols.back().id != -1)) {
+        } else if (m_unk_token_id != -1 &&
+                   (!m_fuse_unk || symbols.empty() || symbols.back().id != m_unk_token_id)) {
             append_symbol(m_unk_token_id);
         }
         // else: unresolvable byte and no unk token -> skip it, matching HF tokenizers.
@@ -460,7 +461,12 @@ void BPETokenizerImpl::tokenize_into(std::string_view text, std::vector<int32_t>
         std::unique_lock<std::shared_mutex> lock(m_mutex);
         // TODO: Check if LRU Cache is more effective.
         if (m_cache.size() < m_cache_capacity && initial_num_tokens > 0) {
-            m_cache.emplace(std::move(cache_key), std::vector<int32_t>(out.begin() + out_start, out.end()));
+            m_cache.insert(
+                text,
+                cache_hash,
+                out.begin() + out_start,
+                out.end()
+            );
         }
     }
 }
@@ -476,7 +482,8 @@ BPETokenizerImpl::BPETokenizerImpl(
        m_end_suffix(std::move(end_suffix)),
        m_byte_fallback(byte_fallback),
        m_fuse_unk(fuse_unk),
-       m_cache_capacity(cache_capacity) {
+       m_cache_capacity(cache_capacity),
+       m_cache(cache_capacity) {
     if (const auto unk_it = vocab.find(unk_token); unk_it != vocab.end()) {
         m_unk_token_id = static_cast<int32_t>(unk_it->second);
     }
@@ -511,5 +518,4 @@ BPETokenizerImpl::BPETokenizerImpl(
         const auto token = std::vector<unsigned char>(word.first.begin(), word.first.end());
         m_trie->add(token, word.second);
     }
-    m_cache.reserve(cache_capacity);
 }

--- a/src/bpe_tokenizer.hpp
+++ b/src/bpe_tokenizer.hpp
@@ -12,6 +12,7 @@
 #include <mutex>
 #include <shared_mutex>
 #include "absl/container/flat_hash_map.h"
+#include "bpe_result_cache.hpp"
 #include "utils.hpp"
 
 #ifdef _MSC_VER
@@ -145,11 +146,14 @@ private:
     bool m_byte_fallback = false;
     int32_t m_unk_token_id = -1;
     bool m_fuse_unk = false;
-    size_t m_cache_capacity;
+    size_t m_cache_capacity = 0;
     std::shared_mutex m_mutex;
-    std::unordered_map<std::string, std::vector<int32_t>> m_cache;
+    BPEResultCache m_cache;
 public:
-    BPETokenizerImpl(Vocab vocab, Merges merges): m_vocab(std::move(vocab)), m_merges(std::move(merges)) {};
+    BPETokenizerImpl(Vocab vocab, Merges merges):
+        m_vocab(std::move(vocab)),
+        m_merges(std::move(merges)),
+        m_cache(0) {};
     BPETokenizerImpl(
         Vocab vocab, const TextMerges& merges,
         size_t cache_capacity,

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -461,77 +461,93 @@ std::pair<std::pair<size_t,size_t>, std::pair<size_t,size_t>> PCRE2Wrapper::matc
 }
 
 
-const Trie* Trie::find_child(unsigned char ch) const {
-    auto it = std::lower_bound(
-        m_children.begin(), m_children.end(), ch,
-        [](const std::pair<unsigned char, std::unique_ptr<Trie>>& entry, unsigned char value) {
-            return entry.first < value;
-        });
-    if (it != m_children.end() && it->first == ch) {
-        return it->second.get();
+Trie::Trie() {
+    for (size_t ch = 0; ch < 256; ++ch) {
+        m_root[ch].value = -1;
+        m_root[ch].child = -1;
+        m_root_node[ch] = -1;
     }
-    return nullptr;
+}
+
+int32_t Trie::find_child(const std::vector<Child>& children, unsigned char ch) {
+    auto it = std::lower_bound(
+        children.begin(), children.end(), ch,
+        [](const Child& entry, unsigned char value) { return entry.key < value; });
+    if (it != children.end() && it->key == ch) {
+        return it->node;
+    }
+    return -1;
 }
 
 void Trie::add(const std::vector<unsigned char>& str, const int value, int idx) {
-    if (idx == str.size()) {
-        m_value = value;
-    } else {
-        auto ch = str[idx];
+    if (idx >= static_cast<int>(str.size())) {
+        // Empty key, or an `add` called directly at the end. Never read by
+        // find_longest, exactly as before.
+        m_empty_value = value;
+        return;
+    }
+
+    const unsigned char first = str[idx];
+    if (idx + 1 == static_cast<int>(str.size())) {
+        m_root[first].value = value;
+        return;
+    }
+
+    // Walk/create the depth-1 node, then descend through the pool.
+    int32_t node_idx = m_root_node[first];
+    if (node_idx < 0) {
+        node_idx = static_cast<int32_t>(m_nodes.size());
+        m_nodes.emplace_back();
+        m_root_node[first] = node_idx;
+    }
+    // The depth-1 node is about to hold at least one child, so the flat root slot
+    // must now route this byte to the deep walk.
+    m_root[first].child = node_idx;
+
+    for (int pos = idx + 1; pos < static_cast<int>(str.size()); ++pos) {
+        const unsigned char ch = str[pos];
+        auto& children = m_nodes[node_idx].children;
         auto it = std::lower_bound(
-            m_children.begin(), m_children.end(), ch,
-            [](const std::pair<unsigned char, std::unique_ptr<Trie>>& entry, unsigned char value) {
-                return entry.first < value;
-            });
-        if (it == m_children.end() || it->first != ch) {
-            it = m_children.emplace(it, ch, std::make_unique<Trie>());
+            children.begin(), children.end(), ch,
+            [](const Child& entry, unsigned char key) { return entry.key < key; });
+        if (it == children.end() || it->key != ch) {
+            const int32_t new_idx = static_cast<int32_t>(m_nodes.size());
+            // `children` is a reference into m_nodes; emplace_back may reallocate
+            // the pool, so record the insertion offset and re-acquire afterwards.
+            const auto offset = it - children.begin();
+            m_nodes.emplace_back();
+            m_nodes[node_idx].children.insert(
+                m_nodes[node_idx].children.begin() + offset, Child{new_idx, ch});
+            node_idx = new_idx;
+        } else {
+            node_idx = it->node;
         }
-        it->second->add(str, value, idx + 1);
     }
+    m_nodes[node_idx].value = value;
 }
 
+// Cold path: some key longer than one byte starts with str[idx]. Semantics are
+// those of the original loop -- track the longest key that actually matched and
+// rewind `idx` to its end, not to the end of the walk.
+int Trie::find_longest_deep(const unsigned char* data, int size, int& idx) const {
+    const RootSlot slot = m_root[data[idx]];
+    int token_id = slot.value;
+    ++idx;
+    int end_idx = (token_id != -1) ? idx : idx - 1;
 
-int Trie::find_longest(const std::vector<unsigned char>& str, int& idx) const {
-    int token_id = -1;  // no token found
-    const Trie* current_node = this;
-
-    uint8_t ch = str[idx];
-    int end_idx = idx;
-
-    while (const Trie* next_node = current_node->find_child(ch)) {
-        current_node = next_node;
-        idx++;
-        if (current_node->m_value != -1) {
-            token_id = current_node->m_value;
-            end_idx = idx;
-        }
-        if (idx == str.size()) {
+    int32_t node_idx = slot.child;
+    while (idx < size) {
+        const int32_t next = find_child(m_nodes[node_idx].children, data[idx]);
+        if (next < 0) {
             break;
         }
-        ch = str[idx];
-    }
-    idx = end_idx;
-    return token_id;
-}
-
-int Trie::find_longest(const std::string_view& str, int& idx) const {
-    int token_id = -1;  // no token found
-    const Trie* current_node = this;
-
-    uint8_t ch = str[idx];
-    int end_idx = idx;
-
-    while (const Trie* next_node = current_node->find_child(ch)) {
-        current_node = next_node;
-        idx++;
-        if (current_node->m_value != -1) {
-            token_id = current_node->m_value;
+        node_idx = next;
+        ++idx;
+        const int32_t value = m_nodes[node_idx].value;
+        if (value != -1) {
+            token_id = value;
             end_idx = idx;
         }
-        if (idx == str.size()) {
-            break;
-        }
-        ch = str[idx];
     }
     idx = end_idx;
     return token_id;

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -4,8 +4,10 @@
 
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <string_view>
+#include <vector>
 #include <openvino/runtime/tensor.hpp>
 #include <openvino/frontend/node_context.hpp>
 #include <pcre2.h>
@@ -108,18 +110,82 @@ class PCRE2Wrapper {
         bool m_is_jit = 0;
 };
 
+// Longest-prefix-match lookup table over byte strings.
+//
+// Layout notes. The first byte is resolved through a flat 256-entry table
+// (`m_root`) instead of a binary search, and every deeper node lives in one
+// contiguous pool (`m_nodes`) addressed by index rather than through
+// `std::unique_ptr`. A depth-1 terminal whose node has no children needs no
+// pool access at all, which is the overwhelmingly common case for byte-level
+// BPE vocabularies (256 single-byte entries plus a few hundred longer ones).
+// Deeper walks, which WordPiece needs, keep a sorted per-node child array but
+// with 8-byte entries in pooled nodes instead of 16-byte entries pointing at
+// scattered heap allocations.
 class Trie {
     public:
-        Trie() = default;
+        Trie();
 
         void add(const std::vector<unsigned char>& str, const int value, int idx = 0);
-        int find_longest(const std::vector<unsigned char>& str, int& idx) const;
-        int find_longest(const std::string_view& str, int& idx) const;
+
+        int find_longest(const std::vector<unsigned char>& str, int& idx) const {
+            return find_longest_impl(str.data(), static_cast<int>(str.size()), idx);
+        }
+        int find_longest(const std::string_view& str, int& idx) const {
+            return find_longest_impl(
+                reinterpret_cast<const unsigned char*>(str.data()), static_cast<int>(str.size()), idx);
+        }
 
     private:
-        const Trie* find_child(unsigned char ch) const;
-        std::vector<std::pair<unsigned char, std::unique_ptr<Trie>>> m_children;
-        int m_value = -1;  // -1 for unset value
+        // Depth-1 dispatch entry. `value` is the token id of the one-byte key, or
+        // -1 when that byte is not a key. `child` is the pool index of the node to
+        // continue the walk from, or -1 when nothing longer starts with this byte.
+        // Both being -1 means the byte is absent from the table entirely.
+        struct RootSlot {
+            int32_t value;
+            int32_t child;
+        };
+        struct Child {
+            int32_t node;
+            unsigned char key;
+        };
+        struct Node {
+            int32_t value = -1;  // -1 for unset value
+            std::vector<Child> children;  // sorted by key
+        };
+
+        // Hot path: one indexed load, no search, no pointer chase. Kept in the
+        // header so the depth-1 case inlines into the tokenizer loops.
+        //
+        // `idx >= size` returns -1 and leaves `idx` alone. The previous
+        // implementation read `str[idx]` unconditionally, so it relied on every
+        // caller checking that itself; all four do, and this is a safe superset.
+        int find_longest_impl(const unsigned char* data, int size, int& idx) const {
+            if (idx >= size) {
+                return -1;
+            }
+            const RootSlot slot = m_root[data[idx]];
+            if (slot.child < 0) {
+                // No longer key starts with this byte, so the depth-1 entry, present
+                // or not, is already the answer.
+                idx += (slot.value != -1);
+                return slot.value;
+            }
+            return find_longest_deep(data, size, idx);
+        }
+
+        int find_longest_deep(const unsigned char* data, int size, int& idx) const;
+        static int32_t find_child(const std::vector<Child>& children, unsigned char ch);
+
+        RootSlot m_root[256];
+        std::vector<Node> m_nodes;
+        // Pool index of the depth-1 node per first byte, or -1 when that byte
+        // begins no key. Used only while building: `m_root[ch].child` mirrors it
+        // but deliberately stays -1 until that node actually gains a child, which
+        // is what keeps depth-1 terminals off the deep path.
+        int32_t m_root_node[256];
+        // Value of the empty key. The previous implementation stored it on the root
+        // node, where find_longest never read it; retained for the same reason.
+        int32_t m_empty_value = -1;
 };
 
 bool getenv_bool(const char* env_var, bool default_value);

--- a/tests/bpe_result_cache_test.py
+++ b/tests/bpe_result_cache_test.py
@@ -111,7 +111,8 @@ CONCURRENT_SCRIPT = textwrap.dedent(
 
     def infer_many(_):
         request = compiled.create_infer_request()
-        for _ in range(50):
+        # 8 workers x 125 inferences = 1,000 concurrent inferences.
+        for _ in range(125):
             result = request.infer([text])
             assert result[compiled.output("input_ids")].tolist()[0] == expected
 
@@ -123,3 +124,150 @@ CONCURRENT_SCRIPT = textwrap.dedent(
 
 def test_bpe_cache_concurrent_inference():
     run_subprocess(CONCURRENT_SCRIPT)
+
+
+# The cache stores results of at most four token ids inline in the slot and spills
+# longer ones to a side arena, and keys of at most 15 bytes inside the std::string
+# small-string buffer. These scripts pin both boundaries and the sentinel/NUL rules
+# through the production graph.
+SLOT_BOUNDARY_SCRIPT = textwrap.dedent(
+    r"""
+    import openvino as ov
+    from openvino_tokenizers import convert_tokenizer
+    from tokenizers import Tokenizer
+    from tokenizers.models import BPE
+    from tokenizers.pre_tokenizers import WhitespaceSplit
+    from transformers import PreTrainedTokenizerFast
+
+    # One token per character, so a key of N characters encodes to N tokens and the
+    # key-length and value-length boundaries can be driven independently.
+    letters = "abcdefghijklmnopqrstuvwxyz"
+    vocab = {"[UNK]": 0, **{ch: idx + 1 for idx, ch in enumerate(letters)}}
+    backend = Tokenizer(BPE(vocab=vocab, merges=[], unk_token="[UNK]"))
+    backend.pre_tokenizer = WhitespaceSplit()
+    tokenizer = PreTrainedTokenizerFast(tokenizer_object=backend, unk_token="[UNK]")
+    model = convert_tokenizer(tokenizer, with_detokenizer=False, add_special_tokens=False)
+    bpe_node = next(node for node in model.get_ordered_ops() if node.get_type_name() == "BPETokenizer")
+    bpe_node.set_attribute("cache_capacity", 4096)
+    compiled = ov.Core().compile_model(model, "CPU")
+
+    def encode(text):
+        return compiled([text])["input_ids"].tolist()[0]
+
+    ids = {ch: vocab[ch] for ch in letters}
+
+    # Key lengths straddling the 15-byte small-string boundary, and value lengths
+    # straddling the 4-token inline boundary. Each is checked twice: the first pass
+    # inserts (miss), the second reads back (hit).
+    for length in (1, 3, 4, 5, 6, 14, 15, 16, 17, 31, 32, 33, 64):
+        text = "".join(letters[i % 26] for i in range(length))
+        expected = [ids[ch] for ch in text]
+        assert encode(text) == expected, (length, "miss")
+        assert encode(text) == expected, (length, "hit")
+        # A third read, after other keys have been inserted and the spill arena has
+        # grown, catches a stale pointer into reallocated storage.
+        assert encode(text) == expected, (length, "rehit")
+
+    # Repeated hits on a spilled (>4 token) value, interleaved with fresh inserts
+    # that keep extending the arena.
+    spilled = "".join(letters[i % 26] for i in range(200))
+    spilled_expected = [ids[ch] for ch in spilled]
+    for round_idx in range(20):
+        filler = "".join(letters[(i + round_idx) % 26] for i in range(50 + round_idx))
+        assert encode(filler) == [ids[ch] for ch in filler]
+        assert encode(spilled) == spilled_expected, round_idx
+    """
+)
+
+
+def test_bpe_cache_inline_and_spill_boundaries():
+    run_subprocess(SLOT_BOUNDARY_SCRIPT)
+
+
+NUL_KEY_SCRIPT = textwrap.dedent(
+    r"""
+    import openvino as ov
+    from openvino_tokenizers import convert_tokenizer
+    from tokenizers import Tokenizer
+    from tokenizers.models import BPE
+    from transformers import PreTrainedTokenizerFast
+
+    # Keys containing an embedded NUL, including keys that are equal up to and
+    # including a NUL and differ only after it. A cache that compared keys as
+    # C strings, or hashed only up to the NUL, would confuse these. The last two
+    # pairs put the distinguishing bytes on either side of the 15-byte
+    # small-string boundary, so the NUL and the boundary are exercised together.
+    #
+    # Keys with a *trailing* or lone NUL are deliberately absent: the production
+    # graph resolves those before BPE ("a\x00" -> [unk], "\x00" -> empty),
+    # independently of caching, so they would not test the cache.
+    pairs = [
+        ("a\x00b", 1),
+        ("a\x00c", 2),
+        ("\x00a", 4),
+        ("a\x00b\x00d", 6),
+        ("a\x00b\x00e", 7),
+        ("a\x00b" + "X" * 14, 8),
+        ("a\x00b" + "Y" * 15, 9),
+    ]
+    vocab = {"[UNK]": 0, **{key: token for key, token in pairs}}
+    backend = Tokenizer(BPE(vocab=vocab, merges=[], unk_token="[UNK]"))
+    tokenizer = PreTrainedTokenizerFast(tokenizer_object=backend, unk_token="[UNK]")
+    model = convert_tokenizer(tokenizer, with_detokenizer=False, add_special_tokens=False)
+    bpe_node = next(node for node in model.get_ordered_ops() if node.get_type_name() == "BPETokenizer")
+    bpe_node.set_attribute("cache_capacity", 64)
+    compiled = ov.Core().compile_model(model, "CPU")
+
+    def encode(text):
+        return compiled([text])["input_ids"].tolist()[0]
+
+    # Two passes so the second reads every key back out of the cache.
+    for _ in range(2):
+        for key, token in pairs:
+            assert encode(key) == [token], (key.encode(), token)
+    """
+)
+
+
+def test_bpe_cache_embedded_nul_keys():
+    run_subprocess(NUL_KEY_SCRIPT)
+
+
+SATURATION_SCRIPT = textwrap.dedent(
+    r"""
+    import openvino as ov
+    from openvino_tokenizers import convert_tokenizer
+    from tokenizers import Tokenizer
+    from tokenizers.models import BPE
+    from tokenizers.pre_tokenizers import WhitespaceSplit
+    from transformers import PreTrainedTokenizerFast
+
+    # Saturation must stay gated on entry count, not bytes: a denser slot may not
+    # silently raise the number of cached entries. With capacity 3, keys beyond the
+    # third are never cached but must still tokenize correctly, every time.
+    letters = "abcdefghij"
+    vocab = {"[UNK]": 0, **{ch: idx + 1 for idx, ch in enumerate(letters)}}
+    backend = Tokenizer(BPE(vocab=vocab, merges=[], unk_token="[UNK]"))
+    backend.pre_tokenizer = WhitespaceSplit()
+    tokenizer = PreTrainedTokenizerFast(tokenizer_object=backend, unk_token="[UNK]")
+    model = convert_tokenizer(tokenizer, with_detokenizer=False, add_special_tokens=False)
+    bpe_node = next(node for node in model.get_ordered_ops() if node.get_type_name() == "BPETokenizer")
+    bpe_node.set_attribute("cache_capacity", 3)
+    compiled = ov.Core().compile_model(model, "CPU")
+
+    ids = {ch: vocab[ch] for ch in letters}
+    # Mix of inline-sized and spill-sized results, more distinct keys than capacity.
+    words = ["a", "ab", "abc", "abcd", "abcde", "abcdefghij", "bcd", "cde", "j"]
+    for _ in range(3):
+        for word in words:
+            assert compiled([word])["input_ids"].tolist()[0] == [ids[ch] for ch in word], word
+    # All of them at once, in one row.
+    text = " ".join(words)
+    expected = [ids[ch] for word in words for ch in word]
+    assert compiled([text])["input_ids"].tolist()[0] == expected
+    """
+)
+
+
+def test_bpe_cache_saturation_unchanged():
+    run_subprocess(SATURATION_SCRIPT)

--- a/tests/bpe_result_cache_test.py
+++ b/tests/bpe_result_cache_test.py
@@ -1,0 +1,125 @@
+import subprocess
+import sys
+import textwrap
+
+
+def run_subprocess(script: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+COLLISION_SCRIPT = textwrap.dedent(
+    """
+    import openvino as ov
+    from openvino_tokenizers import convert_tokenizer
+    from tokenizers import Tokenizer
+    from tokenizers.models import BPE
+    from transformers import PreTrainedTokenizerFast
+
+    keys = ["k0", "k8", "k13", "k22"]
+
+    def cache_hash(text):
+        value = 14695981039346656037
+        for byte in text.encode():
+            value ^= byte
+            value = (value * 1099511628211) & ((1 << 64) - 1)
+        return value
+
+    assert len({cache_hash(key) & 7 for key in keys}) == 1
+    vocab = {"[UNK]": 0, **{key: idx + 100 for idx, key in enumerate(keys)}}
+    backend = Tokenizer(BPE(vocab=vocab, merges=[], unk_token="[UNK]"))
+    tokenizer = PreTrainedTokenizerFast(tokenizer_object=backend, unk_token="[UNK]")
+    model = convert_tokenizer(tokenizer, with_detokenizer=False, add_special_tokens=False)
+    bpe_node = next(node for node in model.get_ordered_ops() if node.get_type_name() == "BPETokenizer")
+    bpe_node.set_attribute("cache_capacity", 4)
+    compiled = ov.Core().compile_model(model, "CPU")
+
+    expected = [[vocab[key]] for key in keys]
+    first = [compiled([key])["input_ids"].tolist()[0] for key in keys]
+    second = [compiled([key])["input_ids"].tolist()[0] for key in keys]
+    assert first == expected
+    assert second == expected
+    """
+)
+
+
+def test_bpe_cache_collision_chain():
+    run_subprocess(COLLISION_SCRIPT)
+
+
+EDGE_CASE_SCRIPT = textwrap.dedent(
+    r"""
+    import openvino as ov
+    from openvino_tokenizers import convert_tokenizer
+    from tokenizers import Tokenizer
+    from tokenizers.models import BPE
+    from transformers import PreTrainedTokenizerFast
+
+    vocab = {"[UNK]": 0, "a": 1, "b": 2}
+    backend = Tokenizer(BPE(vocab=vocab, merges=[], unk_token="[UNK]"))
+    tokenizer = PreTrainedTokenizerFast(tokenizer_object=backend, unk_token="[UNK]")
+    model = convert_tokenizer(tokenizer, with_detokenizer=False, add_special_tokens=False)
+    bpe_node = next(node for node in model.get_ordered_ops() if node.get_type_name() == "BPETokenizer")
+    bpe_node.set_attribute("cache_capacity", 4)
+    compiled = ov.Core().compile_model(model, "CPU")
+
+    long_key = "ab" * 128
+    long_value = [1, 2] * 128
+    cases = [
+        (long_key, long_value),
+        ("a", [1]),
+    ]
+    for text, expected in cases:
+        assert compiled([text])["input_ids"].tolist()[0] == expected
+        assert compiled([text])["input_ids"].tolist()[0] == expected
+
+    # Empty strings are removed before BPETokenizer by the production graph.
+    assert compiled([""])["input_ids"].shape[-1] == 0
+    """
+)
+
+
+def test_bpe_cache_empty_and_long_values():
+    run_subprocess(EDGE_CASE_SCRIPT)
+
+
+CONCURRENT_SCRIPT = textwrap.dedent(
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    import openvino as ov
+    from openvino_tokenizers import convert_tokenizer
+    from tokenizers import Tokenizer
+    from tokenizers.models import BPE
+    from tokenizers.pre_tokenizers import WhitespaceSplit
+    from transformers import PreTrainedTokenizerFast
+
+    vocab = {"[UNK]": 0, "a": 1, "b": 2}
+    backend = Tokenizer(BPE(vocab=vocab, merges=[], unk_token="[UNK]"))
+    backend.pre_tokenizer = WhitespaceSplit()
+    tokenizer = PreTrainedTokenizerFast(tokenizer_object=backend, unk_token="[UNK]")
+    model = convert_tokenizer(tokenizer, with_detokenizer=False, add_special_tokens=False)
+    bpe_node = next(node for node in model.get_ordered_ops() if node.get_type_name() == "BPETokenizer")
+    bpe_node.set_attribute("cache_capacity", 2)
+    compiled = ov.Core().compile_model(model, "CPU")
+    expected = [1, 2] * 32
+    text = " ".join(["ab"] * 32)
+
+    def infer_many(_):
+        request = compiled.create_infer_request()
+        for _ in range(50):
+            result = request.infer([text])
+            assert result[compiled.output("input_ids")].tolist()[0] == expected
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(infer_many, range(8)))
+    """
+)
+
+
+def test_bpe_cache_concurrent_inference():
+    run_subprocess(CONCURRENT_SCRIPT)

--- a/tests/layer_tests.py
+++ b/tests/layer_tests.py
@@ -100,6 +100,60 @@ def test_bpe_short_merge_path_matches_hf(synthetic_bpe_tokenizers, text, expecte
     assert ov_ids == expected_ids
 
 
+@pytest.mark.parametrize(
+    "model,texts,expected_ids",
+    [
+        (
+            BPE(
+                vocab={"[UNK]": 0, "a</w>": 1},
+                merges=[],
+                unk_token="[UNK]",
+                end_of_word_suffix="</w>",
+            ),
+            ["a", ""],
+            [[1], []],
+        ),
+        (
+            BPE(
+                vocab={"[UNK]": 0, "<0xC3>": 1, "<0xA9>": 2},
+                merges=[],
+                unk_token="[UNK]",
+                byte_fallback=True,
+            ),
+            ["é", "x"],
+            [[1, 2], [0]],
+        ),
+        (
+            BPE(
+                vocab={"[UNK]": 0, "a": 1},
+                merges=[],
+                unk_token="[UNK]",
+                fuse_unk=True,
+            ),
+            ["xyz", "xay"],
+            [[0], [0, 1, 0]],
+        ),
+    ],
+    ids=["end_suffix_and_empty", "byte_fallback", "fuse_unk"],
+)
+def test_bpe_edge_paths(model, texts, expected_ids):
+    hf_tokenizer = PreTrainedTokenizerFast(
+        tokenizer_object=Tokenizer(model),
+        unk_token="[UNK]",
+    )
+    ov_model = convert_tokenizer(
+        hf_tokenizer,
+        with_detokenizer=False,
+        add_special_tokens=False,
+    )
+    ov_tokenizer = core.compile_model(ov_model, "CPU")
+
+    for text, expected in zip(texts, expected_ids):
+        assert hf_tokenizer(text, add_special_tokens=False)["input_ids"] == expected
+        assert ov_tokenizer([text])["input_ids"][0].tolist() == expected
+        assert ov_tokenizer([text])["input_ids"][0].tolist() == expected
+
+
 def parse_normalization_test_line(line):
     parts, comment = line.split("#", 1)
     parts = [part.strip() for part in parts.split(";")]

--- a/tests/layer_tests.py
+++ b/tests/layer_tests.py
@@ -24,6 +24,7 @@ from openvino_tokenizers.tokenizer_pipeline import (
     SpecialToken,
     SpecialTokensSplit,
     TokenizerPipeline,
+    TrieTokenizerStep,
     UTF8ValidateStep,
 )
 from openvino_tokenizers.utils import TokenzierConversionParams
@@ -766,3 +767,98 @@ def test_numeric_to_string_passthrough():
     compiled_model = core.compile_model(model)
     result = compiled_model([np.array(["hello", "world", "test"])])[0]
     assert list(result.flatten()) == ["hello", "world", "test"]
+
+
+############################################
+############# Test Trie Lookup #############
+############################################
+
+# The Trie longest-prefix table backs BPETokenizer, WordpieceTokenizer, and the
+# standalone TrieTokenizer op. TrieTokenizer is the only one that exposes it
+# without a surrounding tokenizer model, so these tests drive it directly.
+#
+# The op loops `while (idx < size)` and appends whatever find_longest returns,
+# so a position with no match at all does not terminate. Every vocab below is
+# therefore byte-complete (all 256 single bytes present), which is also what
+# real RWKV vocabs are.
+
+TRIE_BYTE_BASE_OFFSET = 1  # id 0 is reserved for the empty vocab entry
+
+
+def build_trie_tokenizer(extra_tokens: dict) -> ov.CompiledModel:
+    """A byte-complete Trie vocab plus `extra_tokens` mapping token bytes to ids."""
+    vocab = [b""] + [bytes([byte]) for byte in range(256)]
+    if extra_tokens:
+        vocab.extend([b""] * (max(extra_tokens.values()) + 1 - len(vocab)))
+        for token, idx in extra_tokens.items():
+            vocab[idx] = token
+
+    step = TrieTokenizerStep(vocab, list(range(len(vocab))))
+    input_node = op.Parameter(Type.string, PartialShape(["?"]))
+    output = _get_opset_factory("opset15").create("StringTensorUnpack", input_node.outputs()).outputs()
+    output = step.get_ov_subgraph(TokenizerPipeline.add_ragged_dimension(output))
+    return core.compile_model(Model(output, [input_node], "trie"), "CPU")
+
+
+def byte_ids(data: bytes) -> list:
+    return [byte + TRIE_BYTE_BASE_OFFSET for byte in data]
+
+
+@pytest.fixture(scope="module")
+def trie_tokenizers():
+    return {
+        # No multi-byte key: exercises the single-byte-only table.
+        "bytes_only": build_trie_tokenizer({}),
+        # Nested strict prefixes: "a" < "ab" < "abcd", with "abc" absent so a walk
+        # can descend past a match and dead-end.
+        "prefixes": build_trie_tokenizer({b"ab": 300, b"abcd": 301}),
+        # High-bit bytes, a 45-byte key (the longest in the Qwen BPE trie), and an
+        # embedded NUL.
+        "wide": build_trie_tokenizer(
+            {b"\x80\xff\x81": 300, b"\xff\x80": 301, b"q" * 45: 302, b"a\x00b": 303}
+        ),
+    }
+
+
+@pytest.mark.parametrize(
+    "vocab_id, text, expected",
+    [
+        # Single-byte-only table: every byte resolves at depth 1.
+        ("bytes_only", b"abc", byte_ids(b"abc")),
+        ("bytes_only", bytes(range(256)), byte_ids(bytes(range(256)))),
+        ("bytes_only", b"\x00\x80\xff\x7f", byte_ids(b"\x00\x80\xff\x7f")),
+        # Longest match wins over any shorter prefix.
+        ("prefixes", b"abcd", [301]),
+        ("prefixes", b"ab", [300]),
+        ("prefixes", b"a", byte_ids(b"a")),
+        # Walk descends "a"->"ab"->"abc" then dead-ends: must return the "ab"
+        # match and rewind the cursor to just past "ab", not past "abc".
+        ("prefixes", b"abc", [300] + byte_ids(b"c")),
+        ("prefixes", b"abce", [300] + byte_ids(b"ce")),
+        ("prefixes", b"abcde", [301] + byte_ids(b"e")),
+        # Same rewind with no depth-1 value consumed before the dead end.
+        ("prefixes", b"abx", [300] + byte_ids(b"x")),
+        # High-bit bytes must not be sign-extended on any path.
+        ("wide", b"\x80\xff\x81", [300]),
+        ("wide", b"\xff\x80", [301]),
+        ("wide", b"\x80\xff", byte_ids(b"\x80\xff")),  # descends then rewinds
+        ("wide", b"\x80\xff\x82", byte_ids(b"\x80\xff\x82")),
+        # 45-byte maximum-length key, and its off-by-one neighbours.
+        ("wide", b"q" * 45, [302]),
+        ("wide", b"q" * 44, byte_ids(b"q" * 44)),
+        ("wide", b"q" * 46, [302] + byte_ids(b"q")),
+        # Embedded NUL inside a key and inside a failing walk.
+        ("wide", b"a\x00b", [303]),
+        ("wide", b"a\x00c", byte_ids(b"a\x00c")),
+        # Leading NUL. A trailing one cannot be tested through this op because
+        # numpy's fixed-width bytes dtype strips trailing NULs from the input.
+        ("wide", b"\x00a", byte_ids(b"\x00a")),
+        # Empty input: no output tokens, and no read past the end.
+        ("wide", b"", []),
+    ],
+)
+def test_trie_find_longest(trie_tokenizers, vocab_id, text, expected):
+    compiled_model = trie_tokenizers[vocab_id]
+    result = compiled_model([text])
+    begin, end = int(result[0][0]), int(result[1][0])
+    assert [int(token) for token in result[2][begin:end]] == expected

--- a/tests/layer_tests.py
+++ b/tests/layer_tests.py
@@ -9,7 +9,7 @@ import openvino as ov
 import pytest
 import requests
 from openvino import Model, PartialShape, Type, op
-from openvino_tokenizers import _get_factory, _get_opset_factory
+from openvino_tokenizers import _get_factory, _get_opset_factory, convert_tokenizer
 from openvino_tokenizers.constants import UTF8ReplaceMode
 from openvino_tokenizers.hf_parser import TransformersTokenizerPipelineParser
 from openvino_tokenizers.tokenizer_pipeline import (
@@ -27,6 +27,9 @@ from openvino_tokenizers.tokenizer_pipeline import (
     UTF8ValidateStep,
 )
 from openvino_tokenizers.utils import TokenzierConversionParams
+from tokenizers import Tokenizer
+from tokenizers.models import BPE
+from transformers import PreTrainedTokenizerFast
 
 from tests.utils import get_hf_tokenizer
 
@@ -42,6 +45,59 @@ class NormalizationTestLine(NamedTuple):
     nfkc: str
     nfkd: str
     comment: str
+
+
+@pytest.fixture(scope="module")
+def synthetic_bpe_tokenizers():
+    vocab = {
+        "[UNK]": 0,
+        "a": 1,
+        "aa": 2,
+        "aaa": 3,
+        "aaaa": 4,
+        "aaaaaaaa": 5,
+        "aaaaaaaaaaaaaaaa": 6,
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": 7,
+        "b": 8,
+        "c": 9,
+        "ab": 10,
+        "bc": 11,
+        "abc": 12,
+    }
+    merges = [
+        ("a", "a"),
+        ("aa", "a"),
+        ("aa", "aa"),
+        ("aaaa", "aaaa"),
+        ("aaaaaaaa", "aaaaaaaa"),
+        ("aaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaa"),
+        ("b", "c"),
+        ("a", "b"),
+        ("a", "bc"),
+    ]
+    backend = Tokenizer(BPE(vocab=vocab, merges=merges, unk_token="[UNK]"))
+    hf_tokenizer = PreTrainedTokenizerFast(tokenizer_object=backend, unk_token="[UNK]")
+    ov_model = convert_tokenizer(hf_tokenizer, with_detokenizer=False, add_special_tokens=False)
+    return hf_tokenizer, core.compile_model(ov_model, "CPU")
+
+
+@pytest.mark.parametrize(
+    "text, expected_ids",
+    [
+        ("aaa", [3]),
+        ("abc", [12]),
+        ("a" * 32, [7]),
+        ("a" * 33, [6, 5, 4, 2, 3]),
+    ],
+    ids=["leftmost_tie", "rank_differs_from_id", "short_path_limit", "priority_queue_fallback"],
+)
+def test_bpe_short_merge_path_matches_hf(synthetic_bpe_tokenizers, text, expected_ids):
+    hf_tokenizer, ov_tokenizer = synthetic_bpe_tokenizers
+    hf_ids = hf_tokenizer(text, add_special_tokens=False)["input_ids"]
+    ov_ids = ov_tokenizer([text])["input_ids"][0].tolist()
+
+    assert hf_ids == expected_ids
+    assert ov_ids == expected_ids
 
 
 def parse_normalization_test_line(line):


### PR DESCRIPTION
Optimizes BPE tokenization in two hot paths:

  - Uses a fixed-array linear merge path for pretokens with up to 32 symbols, retaining the priority queue for longer inputs.
  - Replaces the node-based result cache with a contiguous, open-addressed table. Cache hits compare string_view directly and avoid constructing an owned string.

  The existing cache capacity, synchronization, token IDs, and full-key collision checks are preserved.

  ## Performance

  Benchmarked with Qwen/Qwen3-Reranker-0.6B, 2,000 ShareGPT prompts, batch size 1.

  ### Short merge path

```
   Metric                                 Baseline            Optimized    Change
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━  ━━━━━━━━
   LATENCY BPE mean                       0.458 ms             0.448 ms     -2.2%
  ────────────────────────────  ───────────────────  ───────────────────  ────────
   LATENCY sync throughput       1,795.7 prompts/s    1,857.6 prompts/s     +3.4%
  ────────────────────────────  ───────────────────  ───────────────────  ────────
   THROUGHPUT BPE mean                    0.588 ms             0.565 ms     -3.9%
  ────────────────────────────  ───────────────────  ───────────────────  ────────
   THROUGHPUT sync throughput      572.4 prompts/s      573.7 prompts/s     +0.2%
```

  These results are from single before/after runs.

  ### Open-addressed result cache

  Five interleaved before/after pairs per performance hint:

```
   Metric                                String Cache    Open-Addressed Cache    Mean Change       Paired 95% CI
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━
   LATENCY BPE mean                       0.453548 ms             0.443789 ms         -2.13%    -4.68% to +0.42%
  ─────────────────────────────  ─────────────────────  ──────────────────────  ─────────────  ──────────────────
   LATENCY BPE p50                        0.208900 ms             0.200200 ms         -4.16%    -5.93% to -2.38%
  ─────────────────────────────  ─────────────────────  ──────────────────────  ─────────────  ──────────────────
   LATENCY sync throughput        1,844.467 prompts/s     1,879.074 prompts/s         +1.88%    +1.29% to +2.46%
  ─────────────────────────────  ─────────────────────  ──────────────────────  ─────────────  ──────────────────
   THROUGHPUT BPE mean                    0.563152 ms             0.536678 ms         -4.70%    -5.46% to -3.94%
  ─────────────────────────────  ─────────────────────  ──────────────────────  ─────────────  ──────────────────
   THROUGHPUT BPE p50                     0.334000 ms             0.306500 ms         -8.23%    -9.78% to -6.68%
  ─────────────────────────────  ─────────────────────  ──────────────────────  ─────────────  ──────────────────
   THROUGHPUT async throughput    3,572.159 prompts/s     3,671.403 prompts/s         +2.80%    +0.96% to +4.63%
```

  BPE p50 improved in all ten paired comparisons. No process-level peak-RSS regression was measurable.

  ## Validation

  - All benchmark outputs matched Hugging Face.
  - The interleaved cache benchmark validated 40,000 outputs in aggregate.
  - Tests cover merge ordering, rank/token-ID differences, the 32/33-symbol boundary, collision chains, saturation, long values, repeated hits, and concurrent inference.
  - Also fixes fuse_unk handling and adds coverage for byte fallback and end suffixes.
  - CI separates pass-rate tests from functional tests so functional failures cannot be masked.