### PR TITLE
[Tokenizers] Register RegexNormalization and Sentencepiece ops in the op factory

### DIFF
--- a/src/tokenizers_factory.cpp
+++ b/src/tokenizers_factory.cpp
@@ -55,6 +55,20 @@ ov::OutputVector create_tokenizer_node(const std::string& op_type,
         return std::make_shared<CombineSegments>(inputs)->outputs();
     } else if (op_type == "UTF8Validate") {
         return std::make_shared<UTF8Validate>(inputs)->outputs();
+    } else if (op_type == "RegexNormalization") {
+        auto global_replace = get_attribute_value<bool>(attributes, "global_replace", true);
+        return std::make_shared<RegexNormalization>(inputs, global_replace)->outputs();
+    } else if (op_type == "SentencepieceTokenizer") {
+        auto nbest_size = get_attribute_value<int32_t>(attributes, "nbest_size", 0);
+        auto alpha = get_attribute_value<float>(attributes, "alpha", 0.0f);
+        auto add_bos = get_attribute_value<bool>(attributes, "add_bos", false);
+        auto add_eos = get_attribute_value<bool>(attributes, "add_eos", false);
+        auto reverse = get_attribute_value<bool>(attributes, "reverse", false);
+        return std::make_shared<SentencepieceTokenizer>(inputs, nbest_size, alpha, add_bos, add_eos, reverse)->outputs();
+    } else if (op_type == "SentencepieceDetokenizer") {
+        return std::make_shared<SentencepieceDetokenizer>(inputs)->outputs();
+    } else if (op_type == "SentencepieceStreamDetokenizer") {
+        return std::make_shared<SentencepieceStreamDetokenizer>(inputs)->outputs();
     }
     OPENVINO_THROW("Unsupported operation type: `", op_type, "`");
 }


### PR DESCRIPTION
## Description

`create_tokenizer_node()` is the entry point for building a tokenizer graph programmatically, rather than by converting an existing HF tokenizer. Its whitelist covered the BPE path only, so anything SPM-shaped threw `Unsupported operation type`.

This registers the four ops that were missing:

- **`RegexNormalization`** — escapes whitespace to U+2581 (metaspace) on encode and undoes it on decode.
- **`SentencepieceTokenizer`**, **`SentencepieceDetokenizer`**, **`SentencepieceStreamDetokenizer`** — the SPM tokenize/detokenize path itself.

Attributes are read with the existing `get_attribute_value()` helper, using the same defaults as the corresponding op constructors, so a node built through the factory matches one built directly. No existing behaviour changes — this only adds branches ahead of the final `OPENVINO_THROW`, and the op headers are already pulled in via `tokenizer.hpp`.

The motivating consumer is OpenVINO GenAI's GGUF tokenizer builder, which constructs the tokenizer from the converted model's `rt_info`; gemma4 is SPM-style and needs all four. That work is in openvinotoolkit/openvino.genai#4318, which currently pins its `openvino_tokenizers` submodule to this commit — merging here unblocks it.

## Checklist

- [x] Change is limited to the op factory whitelist; no op semantics touched.
- [ ] Tests. `create_tokenizer_node()` has no unit-test coverage in this repo today; the path is exercised end to end by the GenAI GGUF tokenizer tests in the linked PR. Happy to add a direct test here if preferred.
