### PR TITLE
Fixes a crash in `CharsMapNormalization` on macOS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -409,31 +409,49 @@ if(ENABLE_LTO AND CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
         $<$<CONFIG:Release>:-flto>)
 endif()
 
-# On Linux, set linker options to hide symbols and avoid conflicts with OpenVINO's symbols
+# Hide symbols of statically linked third parties (sentencepiece and its bundled
+# absl / protobuf-lite) to avoid clashes with the same symbols exported by OpenVINO
 if(LINUX)
   target_link_options(${TARGET_NAME} PRIVATE "-Wl,--exclude-libs,ALL")
+elseif(APPLE)
+  # ld64 has no --exclude-libs, so unexport the conflicting namespaces explicitly
+  set(unexported_symbols_file "${CMAKE_CURRENT_BINARY_DIR}/unexported_symbols.txt")
+  file(WRITE "${unexported_symbols_file}"
+"*absl*\n"
+"*google*protobuf*\n"
+"*sentencepiece*\n"
+"*utf8_range*\n"
+"*pcre2*\n")
+  target_link_options(${TARGET_NAME} PRIVATE "-Wl,-unexported_symbols_list,${unexported_symbols_file}")
 endif()
 
 target_compile_definitions(${TARGET_NAME} PRIVATE IMPLEMENT_OPENVINO_EXTENSION_API)
 target_link_libraries(${TARGET_NAME} PRIVATE openvino::runtime openvino::threading)
 
-set(ABSL_DEPENDENCIES
-  absl::flat_hash_map
-  absl::str_format
-  absl::string_view
-)
+# Link a real Abseil only when sentencepiece is built against it as well. With
+# 'SPM_ABSL_PROVIDER=internal' the sources are compiled against sentencepiece's bundled
+# header-only absl shims, so pulling in another Abseil (e.g. the one coming from OpenVINO's
+# protobuf) would put two incompatible implementations of the same `absl` symbols into one
+# process and corrupt objects shared between them.
+if(sentencepiece_FOUND OR NOT SPM_ABSL_PROVIDER STREQUAL "internal")
+  set(ABSL_DEPENDENCIES
+    absl::flat_hash_map
+    absl::str_format
+    absl::string_view
+  )
 
-foreach(absl_dependency IN LISTS ABSL_DEPENDENCIES)
-  if(TARGET ${absl_dependency})
-    get_target_property(absl_dependency_real ${absl_dependency} ALIASED_TARGET)
+  foreach(absl_dependency IN LISTS ABSL_DEPENDENCIES)
+    if(TARGET ${absl_dependency})
+      get_target_property(absl_dependency_real ${absl_dependency} ALIASED_TARGET)
 
-    if(absl_dependency_real)
-      set(absl_dependency ${absl_dependency_real})
+      if(absl_dependency_real)
+        set(absl_dependency ${absl_dependency_real})
+      endif()
+
+      target_link_libraries(${TARGET_NAME} PRIVATE ${absl_dependency})
     endif()
-
-    target_link_libraries(${TARGET_NAME} PRIVATE ${absl_dependency})
-  endif()
-endforeach()
+  endforeach()
+endif()
 
 #
 # Set install RPATH


### PR DESCRIPTION
Root cause: two incompatible `absl` implementations end up in one process.

- SentencePiece is built with `SPM_ABSL_PROVIDER=internal` / `SPM_PROTOBUF_PROVIDER=internal`, so the tokenizers sources are compiled against SentencePiece's bundled header-only `absl` shims and its vendored protobuf-lite.
- The `absl::flat_hash_map` / `absl::str_format` / `absl::string_view` targets were linked whenever they happened to exist in the build tree. They did not exist with the old Protobuf (v21.12), so the loop was a silent no-op. Protobuf 5.26 brings a real Abseil into the OpenVINO build tree, so those targets now exist and a second, layout-incompatible `absl` (same non-versioned namespace) got linked into `libopenvino_tokenizers`.
- `libopenvino_tokenizers` is only symbol-isolated on Linux (`-Wl,--exclude-libs,ALL`); on macOS nothing prevented the duplicated `absl` / protobuf weak symbols from being coalesced across dylibs, which corrupts the mutex used during the lazy `NormalizerSpec` / `Normalizer` initialization in `CharsMapNormalization::evaluate()`.

Changes:
- Link a real Abseil only when SentencePiece is built against one as well (`sentencepiece_FOUND` or `SPM_ABSL_PROVIDER != internal`).
- Extend third-party symbol hiding to macOS: `ld64` has no `--exclude-libs`, so an `-unexported_symbols_list` is generated that unexports `absl`, `google::protobuf`,  `sentencepiece`, `utf8_range` and `pcre2` symbols.

Behavior on Linux/Windows and on conda builds (`SPM_ABSL_PROVIDER=package`) is unchanged.

Tickets: CVS-192825