### PR TITLE
Bump product version 2026.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ else()
 endif()
 
 project(openvino_tokenizers
-        VERSION 2026.4.0.0
+        VERSION 2026.5.0.0
         DESCRIPTION "OpenVINO Tokenizers"
         HOMEPAGE_URL "https://github.com/openvinotoolkit/openvino_tokenizers"
         LANGUAGES CXX C)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openvino-tokenizers"
-version = "2026.4.0.0"
+version = "2026.5.0.0"
 description = "Convert tokenizers into OpenVINO models"
 requires-python = ">=3.10"
 readme = { file = "README.md", content-type="text/markdown" }
@@ -37,7 +37,7 @@ classifiers = [
 
 dependencies = [
     # support of nightly openvino packages with dev suffix
-    "openvino~=2026.4.0.dev"
+    "openvino~=2026.5.0.dev"
 ]
 
 [project.optional-dependencies]
@@ -100,7 +100,7 @@ python_abi = "none"
 requires = [
     "py-build-cmake==0.4.3",
     "cmake~=3.14",
-    "openvino~=2026.4.0.dev"
+    "openvino~=2026.5.0.dev"
 ]
 build-backend = "py_build_cmake.build"
 


### PR DESCRIPTION
Bumps the product version to 2026.5.0 on `master`, following the creation of the 2026.4.0 release branch.

Raised by the `administration/bumpProductVersion` Jenkins job.